### PR TITLE
SQL evolution listed on issue #152, for @extschema@

### DIFF
--- a/sql/functions/apply_cluster.sql
+++ b/sql/functions/apply_cluster.sql
@@ -2,7 +2,7 @@
 * Function to apply cluster from parent to child table
 * Adapted from code fork by https://github.com/dturon/pg_partman
 */
-CREATE FUNCTION apply_cluster(p_parent_schema text, p_parent_tablename text, p_child_schema text, p_child_tablename text) RETURNS void
+CREATE FUNCTION @extschema@.apply_cluster(p_parent_schema text, p_parent_tablename text, p_child_schema text, p_child_tablename text) RETURNS void
     LANGUAGE plpgsql SECURITY DEFINER 
 AS $$
 DECLARE

--- a/sql/functions/apply_constraints.sql
+++ b/sql/functions/apply_constraints.sql
@@ -1,7 +1,7 @@
 /*
  * Apply constraints managed by partman extension
  */
-CREATE FUNCTION apply_constraints(p_parent_table text, p_child_table text DEFAULT NULL, p_analyze boolean DEFAULT FALSE, p_job_id bigint DEFAULT NULL, p_debug boolean DEFAULT FALSE) RETURNS void
+CREATE FUNCTION @extschema@.apply_constraints(p_parent_table text, p_child_table text DEFAULT NULL, p_analyze boolean DEFAULT FALSE, p_job_id bigint DEFAULT NULL, p_debug boolean DEFAULT FALSE) RETURNS void
     LANGUAGE plpgsql
     AS $$
 DECLARE

--- a/sql/functions/apply_foreign_keys.sql
+++ b/sql/functions/apply_foreign_keys.sql
@@ -1,7 +1,7 @@
 /*
  * Apply foreign keys that exist on the given parent to the given child table
  */
-CREATE FUNCTION apply_foreign_keys(p_parent_table text, p_child_table text, p_job_id bigint DEFAULT NULL, p_debug boolean DEFAULT false) RETURNS void
+CREATE FUNCTION @extschema@.apply_foreign_keys(p_parent_table text, p_child_table text, p_job_id bigint DEFAULT NULL, p_debug boolean DEFAULT false) RETURNS void
     LANGUAGE plpgsql
     AS $$
 DECLARE

--- a/sql/functions/apply_privileges.sql
+++ b/sql/functions/apply_privileges.sql
@@ -1,7 +1,7 @@
 /*
  * Apply privileges that exist on a given parent to the given child table
  */
-CREATE FUNCTION apply_privileges(p_parent_schema text, p_parent_tablename text, p_child_schema text, p_child_tablename text, p_job_id bigint DEFAULT NULL) RETURNS void
+CREATE FUNCTION @extschema@.apply_privileges(p_parent_schema text, p_parent_tablename text, p_child_schema text, p_child_tablename text, p_job_id bigint DEFAULT NULL) RETURNS void
     LANGUAGE plpgsql SECURITY DEFINER
     AS $$
 DECLARE

--- a/sql/functions/check_name_length.sql
+++ b/sql/functions/check_name_length.sql
@@ -3,7 +3,7 @@
  * Also appends given suffix and schema if given and truncates the name so that the entire suffix will fit.
  * Returns original name with schema given if it doesn't require truncation
  */
-CREATE FUNCTION check_name_length (p_object_name text, p_suffix text DEFAULT NULL, p_table_partition boolean DEFAULT FALSE) RETURNS text
+CREATE FUNCTION @extschema@.check_name_length (p_object_name text, p_suffix text DEFAULT NULL, p_table_partition boolean DEFAULT FALSE) RETURNS text
     LANGUAGE plpgsql IMMUTABLE
     AS $$
 DECLARE

--- a/sql/functions/check_parent.sql
+++ b/sql/functions/check_parent.sql
@@ -1,7 +1,7 @@
 /*
  * Function to monitor for data getting inserted into parent tables managed by extension
  */
-CREATE FUNCTION check_parent(p_exact_count boolean DEFAULT true) RETURNS SETOF @extschema@.check_parent_table
+CREATE FUNCTION @extschema@.check_parent(p_exact_count boolean DEFAULT true) RETURNS SETOF @extschema@.check_parent_table
     LANGUAGE plpgsql STABLE SECURITY DEFINER 
     AS $$
 DECLARE

--- a/sql/functions/check_subpart_sameconfig.sql
+++ b/sql/functions/check_subpart_sameconfig.sql
@@ -4,7 +4,7 @@
  * This is called by run_maintainance() and at least provides a consistent way to check that I know will run. 
  * If anyone can get a working constraint/trigger, please help!
 */
-CREATE FUNCTION @extschema@.check_subpart_sameconfig(p_parent_table text) 
+CREATE FUNCTION @extschema@.@extschema@.check_subpart_sameconfig(p_parent_table text) 
     RETURNS TABLE (sub_partition_type text
         , sub_control text
         , sub_partition_interval text

--- a/sql/functions/check_subpartition_limits.sql
+++ b/sql/functions/check_subpartition_limits.sql
@@ -2,7 +2,7 @@
  * Check if parent table is a subpartition of an already existing partition set managed by pg_partman
  *  If so, return the limits of what child tables can be created under the given parent table based on its own suffix
  */
-CREATE FUNCTION check_subpartition_limits(p_parent_table text, p_type text, OUT sub_min text, OUT sub_max text) RETURNS record
+CREATE FUNCTION @extschema@.check_subpartition_limits(p_parent_table text, p_type text, OUT sub_min text, OUT sub_max text) RETURNS record
     LANGUAGE plpgsql
     AS $$
 DECLARE

--- a/sql/functions/check_version.sql
+++ b/sql/functions/check_version.sql
@@ -2,7 +2,7 @@
  * Check PostgreSQL version number. Parameter must be full 3 point version.
  * Returns true if current version is greater than or equal to the parameter given.
  */
-CREATE FUNCTION check_version(p_check_version text) RETURNS boolean
+CREATE FUNCTION @extschema@.check_version(p_check_version text) RETURNS boolean
     LANGUAGE plpgsql STABLE
     AS $$
 DECLARE

--- a/sql/functions/create_function_id.sql
+++ b/sql/functions/create_function_id.sql
@@ -1,7 +1,7 @@
 /*
  * Create the trigger function for the parent table of an id-based partition set
  */
-CREATE FUNCTION create_function_id(p_parent_table text, p_job_id bigint DEFAULT NULL) RETURNS void
+CREATE FUNCTION @extschema@.create_function_id(p_parent_table text, p_job_id bigint DEFAULT NULL) RETURNS void
     LANGUAGE plpgsql SECURITY DEFINER
     AS $$
 DECLARE

--- a/sql/functions/create_function_time.sql
+++ b/sql/functions/create_function_time.sql
@@ -1,7 +1,7 @@
 /*
  * Create the trigger function for the parent table of a time-based partition set
  */
-CREATE FUNCTION create_function_time(p_parent_table text, p_job_id bigint DEFAULT NULL) RETURNS void
+CREATE FUNCTION @extschema@.create_function_time(p_parent_table text, p_job_id bigint DEFAULT NULL) RETURNS void
     LANGUAGE plpgsql SECURITY DEFINER
     AS $$
 DECLARE

--- a/sql/functions/create_parent.sql
+++ b/sql/functions/create_parent.sql
@@ -1,7 +1,7 @@
 /*
  * Function to turn a table into the parent of a partition set
  */
-CREATE FUNCTION create_parent(
+CREATE FUNCTION @extschema@.create_parent(
     p_parent_table text
     , p_control text
     , p_type text

--- a/sql/functions/create_partition_id.sql
+++ b/sql/functions/create_partition_id.sql
@@ -1,7 +1,7 @@
 /*
  * Function to create id partitions
  */
-CREATE FUNCTION create_partition_id(p_parent_table text, p_partition_ids bigint[], p_analyze boolean DEFAULT true, p_debug boolean DEFAULT false) RETURNS boolean
+CREATE FUNCTION @extschema@.create_partition_id(p_parent_table text, p_partition_ids bigint[], p_analyze boolean DEFAULT true, p_debug boolean DEFAULT false) RETURNS boolean
     LANGUAGE plpgsql SECURITY DEFINER
     AS $$
 DECLARE

--- a/sql/functions/create_partition_time.sql
+++ b/sql/functions/create_partition_time.sql
@@ -1,7 +1,7 @@
 /*
  * Function to create a child table in a time-based partition set
  */
-CREATE FUNCTION create_partition_time(p_parent_table text, p_partition_times timestamp[], p_analyze boolean DEFAULT true, p_debug boolean DEFAULT false) 
+CREATE FUNCTION @extschema@.create_partition_time(p_parent_table text, p_partition_times timestamp[], p_analyze boolean DEFAULT true, p_debug boolean DEFAULT false) 
 RETURNS boolean
     LANGUAGE plpgsql SECURITY DEFINER
     AS $$

--- a/sql/functions/create_sub_parent.sql
+++ b/sql/functions/create_sub_parent.sql
@@ -6,7 +6,7 @@
  * To avoid logical complications and contention issues, ALL subpartitions must be maintained using run_maintenance().
  * This means the automatic, trigger based partition creation for serial partitioning will not work if it is a subpartition.
  */
-CREATE FUNCTION create_sub_parent(
+CREATE FUNCTION @extschema@.create_sub_parent(
     p_top_parent text
     , p_control text
     , p_type text

--- a/sql/functions/create_trigger.sql
+++ b/sql/functions/create_trigger.sql
@@ -1,7 +1,7 @@
 /*
  * Function to create partitioning trigger on parent table
  */
-CREATE FUNCTION create_trigger(p_parent_table text) RETURNS void
+CREATE FUNCTION @extschema@.create_trigger(p_parent_table text) RETURNS void
     LANGUAGE plpgsql SECURITY DEFINER
     AS $$
 DECLARE

--- a/sql/functions/drop_constraints.sql
+++ b/sql/functions/drop_constraints.sql
@@ -1,7 +1,7 @@
 /*
  * Drop constraints managed by pg_partman
  */
-CREATE FUNCTION drop_constraints(p_parent_table text, p_child_table text, p_debug boolean DEFAULT false) RETURNS void
+CREATE FUNCTION @extschema@.drop_constraints(p_parent_table text, p_child_table text, p_debug boolean DEFAULT false) RETURNS void
     LANGUAGE plpgsql
     AS $$
 DECLARE

--- a/sql/functions/drop_partition_id.sql
+++ b/sql/functions/drop_partition_id.sql
@@ -2,7 +2,7 @@
  * Function to drop child tables from an id-based partition set. 
  * Options to move table to different schema, drop only indexes or actually drop the table from the database.
  */
-CREATE FUNCTION drop_partition_id(p_parent_table text, p_retention bigint DEFAULT NULL, p_keep_table boolean DEFAULT NULL, p_keep_index boolean DEFAULT NULL, p_retention_schema text DEFAULT NULL) RETURNS int
+CREATE FUNCTION @extschema@.drop_partition_id(p_parent_table text, p_retention bigint DEFAULT NULL, p_keep_table boolean DEFAULT NULL, p_keep_index boolean DEFAULT NULL, p_retention_schema text DEFAULT NULL) RETURNS int
     LANGUAGE plpgsql SECURITY DEFINER
     AS $$
 DECLARE

--- a/sql/functions/drop_partition_time.sql
+++ b/sql/functions/drop_partition_time.sql
@@ -2,7 +2,7 @@
  * Function to drop child tables from a time-based partition set.
  * Options to move table to different schema, drop only indexes or actually drop the table from the database.
  */
-CREATE FUNCTION drop_partition_time(p_parent_table text, p_retention interval DEFAULT NULL, p_keep_table boolean DEFAULT NULL, p_keep_index boolean DEFAULT NULL, p_retention_schema text DEFAULT NULL) RETURNS int
+CREATE FUNCTION @extschema@.drop_partition_time(p_parent_table text, p_retention interval DEFAULT NULL, p_keep_table boolean DEFAULT NULL, p_keep_index boolean DEFAULT NULL, p_retention_schema text DEFAULT NULL) RETURNS int
     LANGUAGE plpgsql SECURITY DEFINER
     AS $$
 DECLARE

--- a/sql/functions/partition_data_id.sql
+++ b/sql/functions/partition_data_id.sql
@@ -1,7 +1,7 @@
 /*
  * Populate the child table(s) of an id-based partition set with old data from the original parent
  */
-CREATE FUNCTION partition_data_id(p_parent_table text, p_batch_count int DEFAULT 1, p_batch_interval int DEFAULT NULL, p_lock_wait numeric DEFAULT 0, p_order text DEFAULT 'ASC') RETURNS bigint
+CREATE FUNCTION @extschema@.partition_data_id(p_parent_table text, p_batch_count int DEFAULT 1, p_batch_interval int DEFAULT NULL, p_lock_wait numeric DEFAULT 0, p_order text DEFAULT 'ASC') RETURNS bigint
     LANGUAGE plpgsql SECURITY DEFINER
     AS $$
 DECLARE

--- a/sql/functions/partition_data_time.sql
+++ b/sql/functions/partition_data_time.sql
@@ -1,7 +1,7 @@
 /*
  * Populate the child table(s) of a time-based partition set with old data from the original parent
  */
-CREATE FUNCTION partition_data_time(p_parent_table text, p_batch_count int DEFAULT 1, p_batch_interval interval DEFAULT NULL, p_lock_wait numeric DEFAULT 0, p_order text DEFAULT 'ASC') RETURNS bigint
+CREATE FUNCTION @extschema@.partition_data_time(p_parent_table text, p_batch_count int DEFAULT 1, p_batch_interval interval DEFAULT NULL, p_lock_wait numeric DEFAULT 0, p_order text DEFAULT 'ASC') RETURNS bigint
     LANGUAGE plpgsql SECURITY DEFINER
     AS $$
 DECLARE

--- a/sql/functions/reapply_privileges.sql
+++ b/sql/functions/reapply_privileges.sql
@@ -1,7 +1,7 @@
 /*
  * Function to re-apply ownership & privileges on all child tables in a partition set using parent table as reference
  */
-CREATE FUNCTION reapply_privileges(p_parent_table text) RETURNS void
+CREATE FUNCTION @extschema@.reapply_privileges(p_parent_table text) RETURNS void
     LANGUAGE plpgsql SECURITY DEFINER
     AS $$
 DECLARE

--- a/sql/functions/run_maintenance.sql
+++ b/sql/functions/run_maintenance.sql
@@ -6,7 +6,7 @@
  * For large partition sets, running analyze can cause maintenance to take longer than expected. Can set p_analyze to false to avoid a forced analyze run.
  * Be aware that constraint exclusion may not work properly until an analyze on the partition set is run. 
  */
-CREATE FUNCTION run_maintenance(p_parent_table text DEFAULT NULL, p_analyze boolean DEFAULT true, p_jobmon boolean DEFAULT true, p_debug boolean DEFAULT false) RETURNS void 
+CREATE FUNCTION @extschema@.run_maintenance(p_parent_table text DEFAULT NULL, p_analyze boolean DEFAULT true, p_jobmon boolean DEFAULT true, p_debug boolean DEFAULT false) RETURNS void 
     LANGUAGE plpgsql SECURITY DEFINER
     AS $$
 DECLARE

--- a/sql/functions/show_partition_info.sql
+++ b/sql/functions/show_partition_info.sql
@@ -3,7 +3,7 @@
  * Passing the parent table argument improves performance by avoiding a catalog lookup.
  * Passing an interval lets you set one different than the default configured one if desired.
  */
-CREATE FUNCTION show_partition_info(p_child_table text
+CREATE FUNCTION @extschema@.show_partition_info(p_child_table text
     , p_partition_interval text DEFAULT NULL
     , p_parent_table text DEFAULT NULL
     , OUT child_start_time timestamp

--- a/sql/functions/show_partition_name.sql
+++ b/sql/functions/show_partition_name.sql
@@ -3,7 +3,7 @@
  * If using epoch time partitioning, give the text representation of the timestamp NOT the epoch integer value (use to_timestamp() to convert epoch values).
  * Also returns just the suffix value and true if the child table exists or false if it does not
  */
-CREATE FUNCTION show_partition_name(p_parent_table text, p_value text, OUT partition_table text, OUT suffix_timestamp timestamp, OUT suffix_id bigint, OUT table_exists boolean) RETURNS record
+CREATE FUNCTION @extschema@.show_partition_name(p_parent_table text, p_value text, OUT partition_table text, OUT suffix_timestamp timestamp, OUT suffix_id bigint, OUT table_exists boolean) RETURNS record
     LANGUAGE plpgsql STABLE
     AS $$
 DECLARE

--- a/sql/functions/show_partitions.sql
+++ b/sql/functions/show_partitions.sql
@@ -1,7 +1,7 @@
 /*
  * Function to list all child partitions in a set in logical order.
  */
-CREATE FUNCTION show_partitions (p_parent_table text, p_order text DEFAULT 'ASC') RETURNS TABLE (partition_schemaname text, partition_tablename text)
+CREATE FUNCTION @extschema@.show_partitions (p_parent_table text, p_order text DEFAULT 'ASC') RETURNS TABLE (partition_schemaname text, partition_tablename text)
     LANGUAGE plpgsql STABLE SECURITY DEFINER 
     AS $$
 DECLARE

--- a/sql/functions/undo_partition.sql
+++ b/sql/functions/undo_partition.sql
@@ -3,7 +3,7 @@
  * Function to undo partitioning. Copies data to parent without removing any data from children.
  * Will actually work on any parent/child table set, not just ones created by pg_partman.
  */
-CREATE FUNCTION undo_partition(p_parent_table text, p_batch_count int DEFAULT 1, p_keep_table boolean DEFAULT true, p_jobmon boolean DEFAULT true, p_lock_wait numeric DEFAULT 0) RETURNS bigint
+CREATE FUNCTION @extschema@.undo_partition(p_parent_table text, p_batch_count int DEFAULT 1, p_keep_table boolean DEFAULT true, p_jobmon boolean DEFAULT true, p_lock_wait numeric DEFAULT 0) RETURNS bigint
     LANGUAGE plpgsql SECURITY DEFINER
     AS $$
 DECLARE

--- a/sql/functions/undo_partition_id.sql
+++ b/sql/functions/undo_partition_id.sql
@@ -1,7 +1,7 @@
 /*
  * Function to undo id-based partitioning created by this extension
  */
-CREATE FUNCTION undo_partition_id(p_parent_table text, p_batch_count int DEFAULT 1, p_batch_interval bigint DEFAULT NULL, p_keep_table boolean DEFAULT true, p_lock_wait numeric DEFAULT 0) RETURNS bigint
+CREATE FUNCTION @extschema@.undo_partition_id(p_parent_table text, p_batch_count int DEFAULT 1, p_batch_interval bigint DEFAULT NULL, p_keep_table boolean DEFAULT true, p_lock_wait numeric DEFAULT 0) RETURNS bigint
     LANGUAGE plpgsql SECURITY DEFINER
     AS $$
 DECLARE

--- a/sql/functions/undo_partition_time.sql
+++ b/sql/functions/undo_partition_time.sql
@@ -1,7 +1,7 @@
 /*
  * Function to undo time-based partitioning created by this extension
  */
-CREATE FUNCTION undo_partition_time(p_parent_table text, p_batch_count int DEFAULT 1, p_batch_interval interval DEFAULT NULL, p_keep_table boolean DEFAULT true, p_lock_wait numeric DEFAULT 0) RETURNS bigint 
+CREATE FUNCTION @extschema@.undo_partition_time(p_parent_table text, p_batch_count int DEFAULT 1, p_batch_interval interval DEFAULT NULL, p_keep_table boolean DEFAULT true, p_lock_wait numeric DEFAULT 0) RETURNS bigint 
     LANGUAGE plpgsql SECURITY DEFINER
     AS $$
 DECLARE

--- a/sql/tables/tables.sql
+++ b/sql/tables/tables.sql
@@ -1,4 +1,4 @@
-CREATE TABLE part_config (
+CREATE TABLE @extschema@.part_config (
     parent_table text NOT NULL
     , control text NOT NULL
     , partition_type text NOT NULL
@@ -24,11 +24,11 @@ CREATE TABLE part_config (
     , CONSTRAINT positive_premake_check CHECK (premake > 0)
 );
 CREATE INDEX part_config_type_idx ON @extschema@.part_config (partition_type);
-SELECT pg_catalog.pg_extension_config_dump('part_config', '');
+SELECT pg_catalog.pg_extension_config_dump('@extschema@.part_config', '');
 
 
 -- FK set deferrable because create_parent() inserts to this table before part_config
-CREATE TABLE part_config_sub (
+CREATE TABLE @extschema@.part_config_sub (
     sub_parent text PRIMARY KEY REFERENCES @extschema@.part_config (parent_table) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE INITIALLY DEFERRED
     , sub_partition_type text NOT NULL
     , sub_control text NOT NULL
@@ -48,15 +48,15 @@ CREATE TABLE part_config_sub (
     , sub_jobmon boolean NOT NULL DEFAULT true
     , sub_trigger_exception_handling BOOLEAN DEFAULT false
 );
-SELECT pg_catalog.pg_extension_config_dump('part_config_sub', '');
+SELECT pg_catalog.pg_extension_config_dump('@extschema@.part_config_sub', '');
 
-CREATE TABLE custom_time_partitions (
+CREATE TABLE @extschema@.custom_time_partitions (
     parent_table text NOT NULL
     , child_table text NOT NULL
     , partition_range tstzrange NOT NULL
     , PRIMARY KEY (parent_table, child_table));
-CREATE INDEX custom_time_partitions_partition_range_idx ON custom_time_partitions USING gist (partition_range);
-SELECT pg_catalog.pg_extension_config_dump('custom_time_partitions', '');
+CREATE INDEX custom_time_partitions_partition_range_idx ON @extschema@.custom_time_partitions USING gist (partition_range);
+SELECT pg_catalog.pg_extension_config_dump('@extschema@.custom_time_partitions', '');
 
 
 -- Put constraint functions & definitions here because having them separate makes the ordering of their creation harder to control. Some require the above tables to exist first.

--- a/sql/types/types.sql
+++ b/sql/types/types.sql
@@ -1,1 +1,1 @@
-CREATE TYPE check_parent_table AS (parent_table text, count bigint);
+CREATE TYPE @extschema@.check_parent_table AS (parent_table text, count bigint);


### PR DESCRIPTION
Hello Keith,

Here is my little changelog:

I only changed SQL DDL scripts

* Add **@extschema@**
  * For CREATE TYPE: One occurence
  * For CREATE TABLE: Three occurences
  * For CREATE FUNCTION
  * On function call **pg_catalog.pg_extension_config_dump**
   * Into index creation for table custom_time_partitions

I didn't modify `CREATE FUNCTION` by `CREATE OR REPLACE FUNCTION`.

Thomas