### PR TITLE
Doc update undo partition

### DIFF
--- a/doc/pg_partman.md
+++ b/doc/pg_partman.md
@@ -356,6 +356,7 @@ As a note for people that were not aware, you can name arguments in function cal
  * Does not currently work on native partition sets.
  * If you need to keep the data in your child tables after it is put into the parent, use this function. 
  * Unlike the other undo functions, data cannot be copied in batches smaller than the partition interval. Every run of the function copies an entire partition to the parent.
+ * When this function is run, the trigger on the parent table & the trigger function are immediately dropped (if they still exist). This means any further writes are done to the parent.
  * When this function is run, the **`undo_in_progress`** column in the configuration table is set to true if it was managed by pg_partman. This causes all partition creation and retention management to stop ONLY if it was managed by pg_partman.
  * If you are trying to un-partition a large amount of data automatically, it is recommended to run this function with an external script and appropriate batch settings. This will help avoid transactional locks and prevent a failure from causing an extensive rollback. See **Scripts** section for an included python script that will do this for you.
  * By default, partitions are not DROPPED, they are UNINHERITED. This leave previous child tables exactly as they were but no longer inherited from the parent. Does not work on multiple levels of inheritance (subpartitions) if dropping tables.

--- a/doc/pg_partman.md
+++ b/doc/pg_partman.md
@@ -353,6 +353,7 @@ As a note for people that were not aware, you can name arguments in function cal
 
  * Undo the parent/child table inheritance of any partition set, not just ones managed by `pg_partman`. This function COPIES the data from existing child partitions to the parent table.
      * WARNING: If used on a sub-partitioned set not managed by `pg_partman`, results could be unpredictable. It is not recommended to do so.
+     * WARNING: The partitions will be undone in the ascending order of pg_inherits.inhrelid. It might not be the "logical" order of your partitions.
  * Does not currently work on native partition sets.
  * If you need to keep the data in your child tables after it is put into the parent, use this function. 
  * Unlike the other undo functions, data cannot be copied in batches smaller than the partition interval. Every run of the function copies an entire partition to the parent.


### PR DESCRIPTION
Hi, 

I noticed that the documentation of undo_partition lacks a mention of dropping triggers and functions. I propose to add it.

I was also quite surprise when I realized the partition where not undone in the order I thought they would. I did a bunch of drop / create on my partitions before playing with the undo function  so the "logical" order was not the same as the "creation order" of the partition. I propose to add a warning about that in the undo_partition doc.

Thx for the hard work.
Benoit.