### PR TITLE
Fix missing ELSE in CASE for quarter (3 months) interval partitions.

### DIFF
--- a/sql/functions/show_partition_info.sql
+++ b/sql/functions/show_partition_info.sql
@@ -95,6 +95,9 @@ IF v_control_type = 'time' OR (v_control_type = 'id' AND v_epoch <> 'none') THEN
                     child_start_time := to_timestamp(v_year || '-07-01', 'YYYY-MM-DD');
                 WHEN v_quarter = '4' THEN
                     child_start_time := to_timestamp(v_year || '-10-01', 'YYYY-MM-DD');
+                ELSE
+                    -- handle case when partition name did not use "q" convetion
+                    child_start_time := to_timestamp(v_suffix, v_datetime_string);
             END CASE;
         END IF;
 


### PR DESCRIPTION
In case quarter was not identified, use to_timestamp() as for any other interval. Handy if "datetime_string" is "YYYY_MM_DD" what allows to have a table partitioned by different amount of years/days/months to respect possible growing data density over time.