### PR TITLE
Creating new native partitions whose constraints match rows in the default partition

### DIFF
--- a/sql/functions/create_parent.sql
+++ b/sql/functions/create_parent.sql
@@ -3,20 +3,20 @@ CREATE OR REPLACE FUNCTION @extschema@.create_parent(
     , p_control text
     , p_type text
     , p_interval text
-    , p_constraint_cols text[] DEFAULT NULL 
+    , p_constraint_cols text[] DEFAULT NULL
     , p_premake int DEFAULT 4
-    , p_automatic_maintenance text DEFAULT 'on' 
+    , p_automatic_maintenance text DEFAULT 'on'
     , p_start_partition text DEFAULT NULL
     , p_inherit_fk boolean DEFAULT true
-    , p_epoch text DEFAULT 'none' 
+    , p_epoch text DEFAULT 'none'
     , p_upsert text DEFAULT ''
     , p_publications text[] DEFAULT NULL
     , p_trigger_return_null boolean DEFAULT true
     , p_template_table text DEFAULT NULL
     , p_jobmon boolean DEFAULT true
-    , p_debug boolean DEFAULT false) 
-RETURNS boolean 
-    LANGUAGE plpgsql 
+    , p_debug boolean DEFAULT false)
+RETURNS boolean
+    LANGUAGE plpgsql
     AS $$
 DECLARE
 
@@ -101,8 +101,8 @@ AND c.relname = split_part(p_parent_table, '.', 2)::name;
     IF v_parent_tablename IS NULL THEN
         RAISE EXCEPTION 'Unable to find given parent table in system catalogs. Please create parent table first: %', p_parent_table;
     END IF;
-    
-SELECT attnotnull INTO v_notnull 
+
+SELECT attnotnull INTO v_notnull
 FROM pg_catalog.pg_attribute a
 JOIN pg_catalog.pg_class c ON a.attrelid = c.oid
 JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
@@ -135,7 +135,7 @@ IF p_type = 'native' THEN
     FROM pg_catalog.pg_partitioned_table p
     JOIN pg_catalog.pg_class c ON p.partrelid = c.oid
     JOIN pg_namespace n ON c.relnamespace = n.oid
-    WHERE n.nspname = v_parent_schema::name 
+    WHERE n.nspname = v_parent_schema::name
     AND c.relname = v_parent_tablename::name;
 
     IF v_partstrat <> 'r' OR v_partstrat IS NULL THEN
@@ -171,15 +171,15 @@ IF p_type = 'native' THEN
         v_template_tablename := @extschema@.check_name_length('template_'||v_parent_schema||'_'||v_parent_tablename);
         EXECUTE format('CREATE TABLE IF NOT EXISTS %I.%I (LIKE %I.%I)', '@extschema@', v_template_tablename, v_parent_schema, v_parent_tablename);
 
-        SELECT pg_get_userbyid(c.relowner) INTO v_parent_owner 
+        SELECT pg_get_userbyid(c.relowner) INTO v_parent_owner
         FROM pg_catalog.pg_class c
         JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
-        WHERE n.nspname = v_parent_schema::name 
+        WHERE n.nspname = v_parent_schema::name
         AND c.relname = v_parent_tablename::name;
 
         EXECUTE format('ALTER TABLE %I.%I OWNER TO %I'
-                , '@extschema@' 
-                , v_template_tablename 
+                , '@extschema@'
+                , v_template_tablename
                 , v_parent_owner);
     ELSE
         SELECT n.nspname, c.relname INTO v_template_schema, v_template_tablename
@@ -199,7 +199,7 @@ ELSE
         FROM pg_catalog.pg_partitioned_table p
         JOIN pg_catalog.pg_class c ON p.partrelid = c.oid
         JOIN pg_namespace n ON c.relnamespace = n.oid
-        WHERE n.nspname = v_parent_schema::name 
+        WHERE n.nspname = v_parent_schema::name
         AND c.relname = v_parent_tablename::name;
     END IF;
 
@@ -216,7 +216,7 @@ IF p_publications IS NOT NULL THEN
     IF p_publications = '{}' THEN
         RAISE EXCEPTION 'p_publications cannot be an empty set';
     END IF;
-    FOR v_row IN 
+    FOR v_row IN
         SELECT unnest(p_publications) AS pubname
     LOOP
         SELECT pubname INTO v_publication_exists FROM pg_catalog.pg_publication where pubname = v_row.pubname::name;
@@ -244,7 +244,7 @@ END IF;
 
 -- If this parent table has siblings that are also partitioned (subpartitions), ensure this parent gets added to part_config_sub table so future maintenance will subpartition it
 -- Just doing in a loop to avoid having to assign a bunch of variables (should only run once, if at all; constraint should enforce only one value.)
-FOR v_row IN 
+FOR v_row IN
     WITH parent_table AS (
         SELECT h.inhparent AS parent_oid
         FROM pg_catalog.pg_inherits h
@@ -253,7 +253,7 @@ FOR v_row IN
         WHERE c.relname = v_parent_tablename::name
         AND n.nspname = v_parent_schema::name
     ), sibling_children AS (
-        SELECT i.inhrelid::regclass::text AS tablename 
+        SELECT i.inhrelid::regclass::text AS tablename
         FROM pg_inherits i
         JOIN parent_table p ON i.inhparent = p.parent_oid
     )
@@ -324,7 +324,7 @@ LOOP
         , v_row.sub_upsert
         , v_row.sub_trigger_return_null
         , v_row.sub_template_table);
-    
+
 END LOOP;
 
 IF v_control_type = 'time' OR (v_control_type = 'id' AND p_epoch <> 'none') THEN
@@ -379,14 +379,14 @@ IF v_control_type = 'time' OR (v_control_type = 'id' AND p_epoch <> 'none') THEN
             v_base_timestamp := date_trunc('quarter', v_start_time);
             v_datetime_string = 'YYYY"q"Q';
         ELSE
-            v_base_timestamp := date_trunc('month', v_start_time); 
+            v_base_timestamp := date_trunc('month', v_start_time);
             v_datetime_string := v_datetime_string || '_MM';
         END IF;
         IF v_time_interval < '1 month' THEN
             IF p_interval = 'weekly' THEN
                 v_base_timestamp := date_trunc('week', v_start_time);
                 v_datetime_string := 'IYYY"w"IW';
-            ELSE 
+            ELSE
                 v_base_timestamp := date_trunc('day', v_start_time);
                 v_datetime_string := v_datetime_string || '_DD';
             END IF;
@@ -409,7 +409,7 @@ IF v_control_type = 'time' OR (v_control_type = 'id' AND p_epoch <> 'none') THEN
                 v_partition_time := (v_base_timestamp + (v_time_interval * v_count))::timestamptz;
                 v_partition_time_array := array_append(v_partition_time_array, v_partition_time);
             EXCEPTION WHEN datetime_field_overflow THEN
-                RAISE WARNING 'Attempted partition time interval is outside PostgreSQL''s supported time range. 
+                RAISE WARNING 'Attempted partition time interval is outside PostgreSQL''s supported time range.
                     Child partition creation after time % skipped', v_partition_time;
                 v_step_overflow_id := add_step(v_job_id, 'Attempted partition time interval is outside PostgreSQL''s supported time range.');
                 PERFORM update_step(v_step_overflow_id, 'CRITICAL', 'Child partition creation after time '||v_partition_time||' skipped');
@@ -432,7 +432,7 @@ IF v_control_type = 'time' OR (v_control_type = 'id' AND p_epoch <> 'none') THEN
         , datetime_string
         , automatic_maintenance
         , inherit_fk
-        , jobmon 
+        , jobmon
         , upsert
         , trigger_return_null
         , template_table
@@ -452,13 +452,13 @@ IF v_control_type = 'time' OR (v_control_type = 'id' AND p_epoch <> 'none') THEN
         , p_upsert
         , p_trigger_return_null
         , v_template_schema||'.'||v_template_tablename
-        , p_publications); 
+        , p_publications);
 
     RAISE DEBUG 'create_parent: v_partition_time_array: %', v_partition_time_array;
 
     v_last_partition_created := @extschema@.create_partition_time(p_parent_table, v_partition_time_array, false);
 
-    IF v_last_partition_created = false THEN 
+    IF v_last_partition_created = false THEN
         -- This can happen with subpartitioning when future or past partitions prevent child creation because they're out of range of the parent
         -- First see if this parent is a subpartition managed by pg_partman
         WITH top_oid AS (
@@ -468,8 +468,8 @@ IF v_control_type = 'time' OR (v_control_type = 'id' AND p_epoch <> 'none') THEN
             JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
             WHERE c.relname = v_parent_tablename::name
             AND n.nspname = v_parent_schema::name
-        ) SELECT n.nspname, c.relname 
-        INTO v_top_parent_schema, v_top_parent_table 
+        ) SELECT n.nspname, c.relname
+        INTO v_top_parent_schema, v_top_parent_table
         FROM pg_catalog.pg_class c
         JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
         JOIN top_oid t ON c.oid = t.top_parent_oid
@@ -507,7 +507,7 @@ IF v_control_type = 'time' OR (v_control_type = 'id' AND p_epoch <> 'none') THEN
             EXECUTE format('SELECT set_config(%L, %L, %L)', 'search_path', v_old_search_path, 'false');
 
             RETURN v_success;
-        END IF; 
+        END IF;
     END IF; -- End v_last_partition IF
 
     IF v_jobmon_schema IS NOT NULL THEN
@@ -522,7 +522,7 @@ IF v_control_type = 'id' AND p_epoch = 'none' THEN
         RAISE EXCEPTION 'Interval for serial, non-native partitioning must be greater than or equal to 10';
     END IF;
 
-    -- Check if parent table is a subpartition of an already existing id partition set managed by pg_partman. 
+    -- Check if parent table is a subpartition of an already existing id partition set managed by pg_partman.
     WHILE v_higher_parent_table IS NOT NULL LOOP -- initially set in DECLARE
         WITH top_oid AS (
             SELECT i.inhparent AS top_parent_oid
@@ -568,12 +568,12 @@ IF v_control_type = 'id' AND p_epoch = 'none' THEN
     v_starting_partition_id := v_max - (v_max % v_id_interval);
     FOR i IN 0..p_premake LOOP
         -- Only make previous partitions if ID value is less than the starting value and positive (and custom start partition wasn't set)
-        IF p_start_partition IS NULL AND 
-            (v_starting_partition_id - (v_id_interval*i)) > 0 AND 
-            (v_starting_partition_id - (v_id_interval*i)) < v_starting_partition_id 
+        IF p_start_partition IS NULL AND
+            (v_starting_partition_id - (v_id_interval*i)) > 0 AND
+            (v_starting_partition_id - (v_id_interval*i)) < v_starting_partition_id
         THEN
             v_partition_id_array = array_append(v_partition_id_array, (v_starting_partition_id - v_id_interval*i));
-        END IF; 
+        END IF;
         v_partition_id_array = array_append(v_partition_id_array, (v_id_interval*i) + v_starting_partition_id);
     END LOOP;
 
@@ -598,13 +598,13 @@ IF v_control_type = 'id' AND p_epoch = 'none' THEN
         , p_control
         , p_premake
         , p_constraint_cols
-        , p_automatic_maintenance 
+        , p_automatic_maintenance
         , p_inherit_fk
         , p_jobmon
         , p_upsert
         , p_trigger_return_null
         , v_template_schema||'.'||v_template_tablename
-        , p_publications); 
+        , p_publications);
 
     v_last_partition_created := @extschema@.create_partition_id(p_parent_table, v_partition_id_array, false);
 
@@ -666,7 +666,7 @@ IF p_type = 'native' AND current_setting('server_version_num')::int >= 110000 TH
     -- Add default partition to native sets in PG11+
 
     v_default_partition := @extschema@.check_name_length(v_parent_tablename, '_default', FALSE);
-    v_sql := 'CREATE'; 
+    v_sql := 'CREATE';
     IF v_unlogged = 'u' THEN
         v_sql := v_sql ||' UNLOGGED';
     END IF;
@@ -696,7 +696,7 @@ IF p_type <> 'native' THEN
             PERFORM update_step(v_step_id, 'OK', 'Time function created');
         END IF;
     ELSIF v_control_type = 'id' THEN
-        PERFORM @extschema@.create_function_id(p_parent_table, v_job_id);  
+        PERFORM @extschema@.create_function_id(p_parent_table, v_job_id);
         IF v_jobmon_schema IS NOT NULL THEN
             PERFORM update_step(v_step_id, 'OK', 'ID function created');
         END IF;
@@ -746,4 +746,3 @@ DETAIL: %
 HINT: %', ex_message, ex_context, ex_detail, ex_hint;
 END
 $$;
-

--- a/sql/functions/create_partition_default.sql
+++ b/sql/functions/create_partition_default.sql
@@ -1,0 +1,61 @@
+CREATE FUNCTION @extschema@.create_partition_default(p_parent_table text, p_job_id bigint DEFAULT NULL)
+    RETURNS void
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+
+v_default_partition     text;
+v_parent_schema         text;
+v_parent_table          text;
+v_parent_tablename      text;
+v_parent_tablespace     text;
+v_partition_type        text;
+v_unlogged              text;
+v_sql                   text;
+
+BEGIN
+
+SELECT n.nspname, c.relname, t.spcname, c.relpersistence
+INTO v_parent_schema, v_parent_tablename, v_parent_tablespace, v_unlogged
+FROM pg_catalog.pg_class c
+JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
+LEFT OUTER JOIN pg_catalog.pg_tablespace t ON c.reltablespace = t.oid
+WHERE n.nspname = split_part(p_parent_table, '.', 1)::name
+AND c.relname = split_part(p_parent_table, '.', 2)::name;
+
+IF v_parent_tablename IS NULL THEN
+    RAISE EXCEPTION 'Unable to find given parent table in system catalogs. Please create parent table first: %', p_parent_table;
+END IF;
+
+SELECT parent_table
+    , partition_type
+INTO v_parent_table
+    , v_partition_type
+FROM @extschema@.part_config
+WHERE parent_table = p_parent_table;
+
+IF v_partition_type = 'native' AND current_setting('server_version_num')::int >= 110000 THEN
+    -- Add default partition to native sets in PG11+
+
+    v_default_partition := @extschema@.check_name_length(v_parent_tablename, '_default', FALSE);
+    v_sql := 'CREATE';
+    IF v_unlogged = 'u' THEN
+        v_sql := v_sql ||' UNLOGGED';
+    END IF;
+    -- Same INCLUDING list is used in create_partition_*()
+    v_sql := v_sql || format(' TABLE %I.%I (LIKE %I.%I INCLUDING DEFAULTS INCLUDING CONSTRAINTS INCLUDING STORAGE INCLUDING COMMENTS)'
+        , v_parent_schema, v_default_partition, v_parent_schema, v_parent_tablename);
+    EXECUTE v_sql;
+    v_sql := format('ALTER TABLE %I.%I ATTACH PARTITION %I.%I DEFAULT'
+        , v_parent_schema, v_parent_tablename, v_parent_schema, v_default_partition);
+    EXECUTE v_sql;
+
+    IF v_parent_tablespace IS NOT NULL THEN
+        EXECUTE format('ALTER TABLE %I.%I SET TABLESPACE %I', v_parent_schema, v_default_partition, v_parent_tablespace);
+    END IF;
+
+    -- NOTE: Privileges currently not automatically inherited for native
+    PERFORM @extschema@.apply_privileges(v_parent_schema, v_parent_tablename, v_parent_schema, v_default_partition, p_job_id);
+END IF;
+END
+$$;

--- a/sql/functions/create_partition_time.sql
+++ b/sql/functions/create_partition_time.sql
@@ -13,6 +13,7 @@ v_analyze                       boolean := FALSE;
 v_control                       text;
 v_control_type                  text;
 v_datetime_string               text;
+v_default_partition             text;
 v_epoch                         text;
 v_exists                        smallint;
 v_grantees                      text[];
@@ -220,7 +221,25 @@ FOREACH v_time IN ARRAY p_partition_times LOOP
             PERFORM @extschema@.inherit_template_properties(p_parent_table, v_parent_schema, v_partition_name);
         END IF;
 
+        v_default_partition := @extschema@.check_name_length(v_parent_tablename, '_default', FALSE);
+
         IF v_epoch = 'none' THEN
+            -- Move all values from the default partition into the new partition before running ATTACH PARTITION
+            EXECUTE format($_$WITH default_data AS (
+                    DELETE FROM %I.%I
+                    WHERE %I >= %L AND %I < %L
+                    RETURNING *
+                )
+                INSERT INTO %I.%I
+                SELECT * FROM default_data$_$
+                , v_parent_schema
+                , v_default_partition
+                , v_control
+                , v_partition_timestamp_start
+                , v_control
+                , v_partition_timestamp_end
+                , v_parent_schema
+                , v_partition_name);
             -- Attach with normal, time-based values for native constraint
             EXECUTE format('ALTER TABLE %I.%I ATTACH PARTITION %I.%I FOR VALUES FROM (%L) TO (%L)'
                 , v_parent_schema
@@ -232,6 +251,22 @@ FOREACH v_time IN ARRAY p_partition_times LOOP
         ELSE
             -- Must attach with integer based values for native constraint and epoch
             IF v_epoch = 'seconds' THEN
+                -- Move all values from the default partition into the new partition before running ATTACH PARTITION
+                EXECUTE format($_$WITH default_data AS (
+                        DELETE FROM %I.%I
+                        WHERE %I >= %L AND %I < %L
+                        RETURNING *
+                    )
+                    INSERT INTO %I.%I
+                    SELECT * FROM default_data$_$
+                    , v_parent_schema
+                    , v_default_partition
+                    , v_control
+                    , EXTRACT('epoch' FROM v_partition_timestamp_start)
+                    , v_control
+                    , EXTRACT('epoch' FROM v_partition_timestamp_end)
+                    , v_parent_schema
+                    , v_partition_name);
                 EXECUTE format('ALTER TABLE %I.%I ATTACH PARTITION %I.%I FOR VALUES FROM (%L) TO (%L)'
                     , v_parent_schema
                     , v_parent_tablename
@@ -240,6 +275,22 @@ FOREACH v_time IN ARRAY p_partition_times LOOP
                     , EXTRACT('epoch' FROM v_partition_timestamp_start)
                     , EXTRACT('epoch' FROM v_partition_timestamp_end));
             ELSIF v_epoch = 'milliseconds' THEN
+                -- Move all values from the default partition into the new partition before running ATTACH PARTITION
+                EXECUTE format($_$WITH default_data AS (
+                        DELETE FROM %I.%I
+                        WHERE %I >= %L AND %I < %L
+                        RETURNING *
+                    )
+                    INSERT INTO %I.%I
+                    SELECT * FROM default_data$_$
+                    , v_parent_schema
+                    , v_default_partition
+                    , v_control
+                    , EXTRACT('epoch' FROM v_partition_timestamp_start) * 1000
+                    , v_control
+                    , EXTRACT('epoch' FROM v_partition_timestamp_end) * 1000
+                    , v_parent_schema
+                    , v_partition_name);
                 EXECUTE format('ALTER TABLE %I.%I ATTACH PARTITION %I.%I FOR VALUES FROM (%L) TO (%L)'
                     , v_parent_schema
                     , v_parent_tablename


### PR DESCRIPTION
Given:

```sql
CREATE EXTENSION pg_partman;
CREATE EXTENSION pgcrypto;

/** removed not nulls */
CREATE TABLE scans (
    id uuid DEFAULT gen_random_uuid(),
    scan float,
    created_at timestamptz
) PARTITION BY RANGE(created_at);

SELECT create_parent('public.scans', 'created_at', 'native', 'daily', p_debug => true);

INSERT INTO scans (scan, created_at)
SELECT random(), x
FROM generate_series(CURRENT_TIMESTAMP, CURRENT_TIMESTAMP + '30 days'::interval, '2 seconds'::interval) x;

SELECT run_maintenance();
```

The run maintenance would fail: with native partitioning, a new partition cannot be attached if the partition constraint matches rows that currently exist in the default partition.

This series of commits addresses the issue by performing the following:

1. (Whitespace cleanup in files I modified. Yay Atom!)
1. Add a `create_partition_default` function. This functions creates a default partition using native partitioning that is available for PostgreSQL 11+. This also modifies the `create_parent` code to create the default partition right after the new parent table is inserted into the partition config. This allows the creation of the initial partitions to succeed
1. Move any rows from the default partition that match the constraints of a newly created partition into said partition prior to attaching to the parent table. This ensures that `run_maintenance` will succeed with native partitioning for the above case.

This patch lacks updated documentation in pg_partman.md for the `create_partition_default` function as well as pgtap tests, but willing to add if needed.