### PR TITLE
Add INCLUDING GENERATED in includes for postgresql 12

### DIFF
--- a/sql/functions/create_parent.sql
+++ b/sql/functions/create_parent.sql
@@ -706,8 +706,12 @@ IF p_type = 'native' AND current_setting('server_version_num')::int >= 110000 TH
     */
 
     -- Same INCLUDING list is used in create_partition_*(). INDEXES is handled when partition is attached if it's supported.
-    v_sql := v_sql || format(' TABLE %I.%I (LIKE %I.%I INCLUDING DEFAULTS INCLUDING CONSTRAINTS INCLUDING STORAGE INCLUDING COMMENTS)'
+    v_sql := v_sql || format(' TABLE %I.%I (LIKE %I.%I INCLUDING DEFAULTS INCLUDING CONSTRAINTS INCLUDING STORAGE INCLUDING COMMENTS'
         , v_parent_schema, v_default_partition, v_parent_schema, v_parent_tablename);
+    IF current_setting('server_version_num')::int >= 120000 THEN
+        v_sql := v_sql || ' INCLUDING GENERATED';
+    END IF;
+    v_sql := v_sql || ')';
     EXECUTE v_sql;
     v_sql := format('ALTER TABLE %I.%I ATTACH PARTITION %I.%I DEFAULT'
         , v_parent_schema, v_parent_tablename, v_parent_schema, v_default_partition);

--- a/sql/functions/create_partition_id.sql
+++ b/sql/functions/create_partition_id.sql
@@ -146,6 +146,9 @@ FOREACH v_id IN ARRAY p_partition_ids LOOP
             , v_partition_name
             , v_parent_schema
             , v_parent_tablename);
+    IF current_setting('server_version_num')::int >= 120000 THEN
+        v_sql := v_sql || 'INCLUDING GENERATED ';
+    END IF;
 
     SELECT sub_partition_type, sub_control INTO v_sub_partition_type, v_sub_control 
     FROM @extschema@.part_config_sub 

--- a/sql/functions/create_partition_time.sql
+++ b/sql/functions/create_partition_time.sql
@@ -192,6 +192,9 @@ FOREACH v_time IN ARRAY p_partition_times LOOP
                                 , v_partition_name
                                 , v_parent_schema
                                 , v_parent_tablename);
+    IF current_setting('server_version_num')::int >= 120000 THEN
+        v_sql := v_sql || 'INCLUDING GENERATED ';
+    END IF;
 
     SELECT sub_partition_type, sub_control INTO v_sub_partition_type, v_sub_control 
     FROM @extschema@.part_config_sub 


### PR DESCRIPTION
When using generated columns now available in postgresql 12 https://www.postgresql.org/docs/12/ddl-generated-columns.html, pg_partman creates new tables and partitions without copying the generated expressions.  This adds the "INCLUDING GENERATED" like_option only if the postgres version is at least 12.