### PR TITLE
Comparasion between timestamptz and null is always null

### DIFF
--- a/sql/functions/run_maintenance.sql
+++ b/sql/functions/run_maintenance.sql
@@ -227,7 +227,7 @@ LOOP
         IF p_debug THEN
             RAISE NOTICE 'run_maint: v_current_partition_timestamp: %, v_max_time_parent: %', v_current_partition_timestamp, v_max_time_parent;
         END IF;
-        IF v_max_time_parent > v_current_partition_timestamp THEN
+        IF v_current_partition_timestamp IS NULL OR v_max_time_parent > v_current_partition_timestamp THEN
             SELECT suffix_timestamp INTO v_current_partition_timestamp FROM @extschema@.show_partition_name(v_row.parent_table, v_max_time_parent::text);
         END IF;
 


### PR DESCRIPTION
If v_current_partition_timestamp is NULL (there is no data in the
partitioned tables), the comparison is always false, even if the
default table have data.
This error avoid setting the correct value for v_current_partition_timestamp
avoiding the creation of new partitions.

This query returns true:
SELECT ('2018-03-11 02:30'::timestamp > NULL) IS NULL;

Fixes #303 