### PR TITLE
Fixes in maintenance functions to support epoch partitioning and camel case table name

### DIFF
--- a/sql/functions/partition_data_time.sql
+++ b/sql/functions/partition_data_time.sql
@@ -257,11 +257,11 @@ FOR i IN 1..p_batch_count LOOP
 
         -- Temp table created above to avoid excessive temp creation in loop
         EXECUTE format('WITH partition_data AS (
-                DELETE FROM %1$I.%2$I WHERE %3$I >= %4$L AND %3$I < %5$L RETURNING *)
+                DELETE FROM %1$I.%2$I WHERE %3$s >= %4$L AND %3$s < %5$L RETURNING *)
             INSERT INTO partman_temp_data_storage SELECT * FROM partition_data'
             , v_source_schemaname
             , v_source_tablename
-            , v_control
+            , v_partition_expression
             , v_min_partition_timestamp
             , v_max_partition_timestamp);
 


### PR DESCRIPTION
Hi @keithf4 ,

Couple of issues I faced when setting pg_partman in my project

Issue 1: When I ran `CALL public.partition_data_proc('public.Register');`  to move the data from `default` partition to new child partition I got below error when working with epoch range partition

```sql
mdm4=# CALL public.partition_data_proc('public.Register');
ERROR:  invalid input syntax for integer: "2020-09-01 00:00:00+00"
LINE 2: ...OM public."Register_default" WHERE "RegEpoch" >= '2020-09-0...
                                                             ^
QUERY:  WITH partition_data AS (
                DELETE FROM public."Register_default" WHERE "RegEpoch" >= '2020-09-01 00:00:00+00' AND "RegEpoch" < '2020-10-01 00:00:00+00' RETURNING *)
            INSERT INTO partman_temp_data_storage SELECT * FROM partition_data
CONTEXT:  PL/pgSQL function partition_data_time(text,integer,interval,numeric,text,boolean,text) line 249 at EXECUTE
```

to fix this I have used `v_partition_expression` instead of `v_control` 

Issue 2: When I ran `run_maintenance` to create new child partitions I got below error as we use CamelCase table name

```sql
select run_maintenance(
  p_parent_table := 'public.Register',
  p_debug := TRUE
);

ERROR: relation "public.register" does not exist
CONTEXT: SQL statement "SELECT pg_get_expr(relpartbound, v_row.parent_table::regclass)                            FROM pg_catalog.pg_class c
JOIN pg_catalog.pg_namespace n on c.relnamespace = n.oid
WHERE n.nspname = v_parent_schema
AND c.relname = v_default_tablename"
PL/pgSQL function run_maintenance(text,boolean,boolean,boolean) line 157 at SQL statement
```

to fix this I used formatted sql to support camel case table name.

