### PR TITLE
BUGFIX: Certain index statements lead to invalid generated SQL in inherit_template_properties

### DIFF
--- a/sql/functions/inherit_template_properties.sql
+++ b/sql/functions/inherit_template_properties.sql
@@ -153,11 +153,12 @@ IF current_setting('server_version_num')::int >= 100000 THEN
             -- statement column should be just the portion of the index definition that defines what it actually is
             v_sql := format('CREATE %s INDEX ON %I.%I %s', CASE WHEN v_index_list.indisunique = TRUE THEN 'UNIQUE' ELSE '' END, v_child_schema, v_child_tablename, v_index_list.statement);
             IF v_index_list.tablespace_name IS NOT NULL THEN
-                v_sql := v_sql || format(' TABLESPACE %I', v_index_list.tablespace_name);
+                execute format('SET LOCAL default_tablespace = %s',  v_index_list.tablespace_name);
             END IF;
 
             RAISE DEBUG 'Create index: %', v_sql;
             EXECUTE v_sql;
+            RESET default_tablespace;
 
         END IF;
 

--- a/sql/functions/inherit_template_properties.sql
+++ b/sql/functions/inherit_template_properties.sql
@@ -153,7 +153,7 @@ IF current_setting('server_version_num')::int >= 100000 THEN
             -- statement column should be just the portion of the index definition that defines what it actually is
             v_sql := format('CREATE %s INDEX ON %I.%I %s', CASE WHEN v_index_list.indisunique = TRUE THEN 'UNIQUE' ELSE '' END, v_child_schema, v_child_tablename, v_index_list.statement);
             IF v_index_list.tablespace_name IS NOT NULL THEN
-                execute format('SET LOCAL default_tablespace = %s',  v_index_list.tablespace_name);
+                execute format('SET LOCAL default_tablespace = %I',  v_index_list.tablespace_name);
             END IF;
 
             RAISE DEBUG 'Create index: %', v_sql;

--- a/sql/functions/inherit_template_properties.sql
+++ b/sql/functions/inherit_template_properties.sql
@@ -153,7 +153,7 @@ IF current_setting('server_version_num')::int >= 100000 THEN
             -- statement column should be just the portion of the index definition that defines what it actually is
             v_sql := format('CREATE %s INDEX ON %I.%I %s', CASE WHEN v_index_list.indisunique = TRUE THEN 'UNIQUE' ELSE '' END, v_child_schema, v_child_tablename, v_index_list.statement);
             IF v_index_list.tablespace_name IS NOT NULL THEN
-                execute format('SET LOCAL default_tablespace = %I',  v_index_list.tablespace_name);
+                execute format('SET LOCAL default_tablespace = %L',  v_index_list.tablespace_name);
             END IF;
 
             RAISE DEBUG 'Create index: %', v_sql;


### PR DESCRIPTION
This patch resolved my issue (#300). It seems that certain valid index definitions can lead to malformed dynamic SQL in this area of code. Bypassing this syntax and temporarily setting the default_tablespace seems to sidestep the issue.