### PR TITLE
Inherit reloptions

### DIFF
--- a/sql/functions/inherit_template_properties.sql
+++ b/sql/functions/inherit_template_properties.sql
@@ -11,6 +11,7 @@ v_dupe_found            boolean := false;
 v_fk_list               record;
 v_index_list            record;
 v_inherit_fk            boolean;
+v_relopt                record;
 v_parent_index_list     record;
 v_parent_oid            oid;
 v_parent_table          text;
@@ -213,6 +214,20 @@ ELSIF v_template_unlogged = 'p' AND v_child_unlogged = 'u'  THEN
     RAISE DEBUG 'Alter UNLOGGED: %', v_sql;
     EXECUTE v_sql;     
 END IF;
+
+-- Relopts
+FOR v_relopt IN
+    SELECT unnest(reloptions) as value
+    FROM pg_catalog.pg_class
+    WHERE oid = v_template_oid
+LOOP
+    v_sql := format('ALTER TABLE %I.%I set (%s)'
+                    , v_child_schema
+                    , v_child_tablename
+                    , v_relopt.value);
+    RAISE DEBUG 'Set relopts: %', v_sql;
+    EXECUTE v_sql;
+END LOOP;
 
 RETURN true;
 


### PR DESCRIPTION
Hi,

Just faced an interesting situation when reltoptions were not propagated on
children tables. From what I see it's not supported via native partitioning,
but maybe possible to inherit them from a template table. This PR is the most
straightforward change that has worked for particular case I have in mind, so I
wanted to ask if it makes sense or not?