### PR TITLE
feat(drop_partition_time): Add ability to override reference timestamp

### DIFF
--- a/doc/pg_partman.md
+++ b/doc/pg_partman.md
@@ -459,6 +459,7 @@ As a note for people that were not aware, you can name arguments in function cal
  * `p_keep_table` - optional parameter to tell partman whether to keep or drop the table in addition to uninheriting it. TRUE means the table will not actually be dropped; FALSE means the table will be dropped. This function will just use the value configured in **part_config** if not explicitly set. This option is ignored if retention_schema is set.
  * `p_keep_index` - optional parameter to tell partman whether to keep or drop the indexes of the child table when it is uninherited. TRUE means the indexes will be kept; FALSE means all indexes will be dropped. This function will just use the value configured in **part_config** if not explicitly set. This option is ignored if p_keep_table is set to FALSE or if retention_schema is set.
  * `p_retention_schema` - optional parameter to tell partman to move a table to another schema instead of dropping it. Set this to the schema you want the table moved to. This function will just use the value configured in **`part_config`** if not explicitly set. If this option is set, the retention `p_keep_table` & `p_keep_index` parameters are ignored.
+ * `p_reference_timestamp` - optional parameter to tell partman to use a different reference timestamp from which to determine which partitions should be affected, default value is `CURRENT_TIMESTAMP`.
  * Returns the number of partitions affected.
 
 

--- a/sql/functions/drop_partition_time.sql
+++ b/sql/functions/drop_partition_time.sql
@@ -1,4 +1,4 @@
-CREATE FUNCTION @extschema@.drop_partition_time(p_parent_table text, p_retention interval DEFAULT NULL, p_keep_table boolean DEFAULT NULL, p_keep_index boolean DEFAULT NULL, p_retention_schema text DEFAULT NULL) RETURNS int
+CREATE FUNCTION @extschema@.drop_partition_time(p_parent_table text, p_retention interval DEFAULT NULL, p_keep_table boolean DEFAULT NULL, p_keep_index boolean DEFAULT NULL, p_retention_schema text DEFAULT NULL, p_reference_timestamp TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP) RETURNS int
     LANGUAGE plpgsql
     AS $$
 DECLARE
@@ -149,7 +149,7 @@ LOOP
         , v_partition_interval::text
         , p_parent_table);
     -- Add one interval since partition names contain the start of the constraint period
-    IF v_retention < (CURRENT_TIMESTAMP - (v_partition_timestamp + v_partition_interval)) THEN
+    IF v_retention < (p_reference_timestamp - (v_partition_timestamp + v_partition_interval)) THEN
 
         -- Do not allow final partition to be dropped if it is not a sub-partition parent
         SELECT count(*) INTO v_count FROM @extschema@.show_partitions(p_parent_table);

--- a/updates/pg_partman--4.5.1--4.6.0.sql
+++ b/updates/pg_partman--4.5.1--4.6.0.sql
@@ -360,7 +360,7 @@ END
 $$;
 
 
-CREATE OR REPLACE FUNCTION @extschema@.drop_partition_time(p_parent_table text, p_retention interval DEFAULT NULL, p_keep_table boolean DEFAULT NULL, p_keep_index boolean DEFAULT NULL, p_retention_schema text DEFAULT NULL) RETURNS int
+CREATE OR REPLACE FUNCTION @extschema@.drop_partition_time(p_parent_table text, p_retention interval DEFAULT NULL, p_keep_table boolean DEFAULT NULL, p_keep_index boolean DEFAULT NULL, p_retention_schema text DEFAULT NULL, p_reference_timestamp TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP) RETURNS int
     LANGUAGE plpgsql
     AS $$
 DECLARE
@@ -511,7 +511,7 @@ LOOP
         , v_partition_interval::text
         , p_parent_table);
     -- Add one interval since partition names contain the start of the constraint period
-    IF v_retention < (CURRENT_TIMESTAMP - (v_partition_timestamp + v_partition_interval)) THEN
+    IF v_retention < (p_reference_timestamp - (v_partition_timestamp + v_partition_interval)) THEN
 
         -- Do not allow final partition to be dropped if it is not a sub-partition parent
         SELECT count(*) INTO v_count FROM @extschema@.show_partitions(p_parent_table);


### PR DESCRIPTION
I was looking through my monkey patches that I was using to fix #369, and I found this small adjustment I had also made. 

It allows you to override the reference timestamp for `drop_partition_time`, this allows one to execute the `drop_partition_time` function with a reference date set either in the past or the future. This is mostly useful for testing scenarios where you're simulating loads over dates in either the future or the past.