### PR TITLE
Fix locking rows when partitioning with a lock timeout

### DIFF
--- a/sql/functions/partition_data_time.sql
+++ b/sql/functions/partition_data_time.sql
@@ -250,7 +250,7 @@ FOR i IN 1..p_batch_count LOOP
         WHILE v_lock_iter <= 5 LOOP
             v_lock_iter := v_lock_iter + 1;
             BEGIN
-                EXECUTE format('SELECT %s FROM ONLY %I.%I WHERE %s >= %L AND %3$s < %5$L FOR UPDATE NOWAIT'
+                EXECUTE format('SELECT %s FROM ONLY %I.%I WHERE %s >= %L AND %4$s < %5$L FOR UPDATE NOWAIT'
                     , v_column_list
                     , v_source_schemaname
                     , v_source_tablename


### PR DESCRIPTION
When running `partition_data_proc()` or `partition_data_time()` with a non-zero value for `p_lock_wait`, the query generated to lock the rows for updating incorrectly includes the table name where it should be including `p_partition_expression`. This PR fixes that issue by indexing the correct argument to `format`.

I don't have a setup to test this, but I ran into this in a production environment while trying to understand why moving data from the default partition didn't appear to be making any progress. I also didn't write any tests because I wasn't sure what minimum level of SQL would be necessary for testing this. Hopefully that's not an issue for getting this merged.

Ultimately this isn't blocking my progress, but I figured I would make this quick update. Let me know if you want me to make any updates to the CHANGELOG or any other files.