### PR TITLE
PostgreSQL 15 compatibility

### DIFF
--- a/src/pg_partman_bgw.c
+++ b/src/pg_partman_bgw.c
@@ -520,7 +520,9 @@ void pg_partman_bgw_run_maint(Datum arg) {
     SPI_finish();
     PopActiveSnapshot();
     CommitTransactionCommand();
+#if (PG_VERSION_NUM < 150000)
     ProcessCompletedNotifies();
+#endif
     pgstat_report_activity(STATE_IDLE, NULL);
     elog(DEBUG1, "pg_partman dynamic BGW shutting down gracefully for database %s.", dbname);
 


### PR DESCRIPTION
Don't call ProcessCompletedNotifies explicitly for PostgreSQL 15+ (postgres/postgres@2e4eae87d02fef51c42c2028b65d85b9e051f9eb)