### PR TITLE
Fix run_maintenace when no default table exists

### DIFF
--- a/sql/functions/run_maintenance.sql
+++ b/sql/functions/run_maintenance.sql
@@ -169,7 +169,7 @@ LOOP
         WHERE n.nspname = v_parent_schema
         AND c.relname = v_default_tablename;
 
-        IF v_is_default != 'DEFAULT' THEN
+        IF v_is_default IS DISTINCT FROM 'DEFAULT' THEN
             v_default_tablename := v_parent_tablename;
         END IF;
     ELSE


### PR DESCRIPTION
We're encountering an error like this when running `CALL run_maintenance_proc()` on our database with a native range partitioned table without partitions:

```sql
psql:.../db/structure.sql:8965: ERROR:  null values cannot be formatted as an SQL identifier
CONTEXT: PL/pgSQL function partman.run_maintenance(text,boolean,boolean) line 323 at EXECUTE
SQL statement "SELECT partman.run_maintenance('public.agent_details', p_jobmon := 't')"
PL/pgSQL function partman.run_maintenance_proc(integer,boolean,boolean) line 42 at EXECUTE
DETAIL:
HINT:
CONTEXT:  PL/pgSQL function partman.run_maintenance(text,boolean,boolean) line 410 at RAISE
SQL statement "SELECT partman.run_maintenance('public.agent_details', p_jobmon := 't')"
PL/pgSQL function partman.run_maintenance_proc(integer,boolean,boolean) line 42 at EXECUTE
```

We're using v4.5.1. I traced it to:

https://github.com/pgpartman/pg_partman/blob/v4.5.1/sql/functions/run_maintenance.sql#L317

`v_default_tablename` is `NULL`.

That should be set to the parent tablename earlier:
https://github.com/pgpartman/pg_partman/blob/v4.5.1/sql/functions/run_maintenance.sql#L168

but `v_is_default` will be `NULL` if there are no partitions at all, and `(NULL != 'DEFAULT') IS NULL`, and `IF NULL THEN ... END` will not enter the conditional block because `NULL` is not `TRUE`, so it doesn't enter the conditional and default to the parent table name.

`(NULL IS DISTINCT FROM 'DEFAULT') IS TRUE`, however, and works the way it should, and preserves `('any string' IS DISTINCT FROM 'DEFAULT') IS TRUE`, while `('DEFAULT' IS DISTINCT FROM 'DEFAULT') IS FALSE`.

Sorry I'm not familiar enough with the test suite to write a test. If someone can provide some pointers I'll have a go. I presume it would require adding a test in `test/test-id-run-maint.sql`?