### PR TITLE
Fix arg ref in SELECT FOR UPDATE format str

### DIFF
--- a/sql/functions/partition_data_time.sql
+++ b/sql/functions/partition_data_time.sql
@@ -246,7 +246,7 @@ FOR i IN 1..p_batch_count LOOP
         WHILE v_lock_iter <= 5 LOOP
             v_lock_iter := v_lock_iter + 1;
             BEGIN
-                EXECUTE format('SELECT %s FROM ONLY %I.%I WHERE %s >= %L AND %4$s < %5$L FOR UPDATE NOWAIT'
+                EXECUTE format('SELECT %s FROM ONLY %I.%I WHERE %s >= %L AND %4$s < %6$L FOR UPDATE NOWAIT'
                     , v_column_list
                     , v_source_schemaname
                     , v_source_tablename


### PR DESCRIPTION
This used to be `%3$s < %5$L` until v4.6.1, which [fixed the 3$ but not the 5$](https://github.com/pgpartman/pg_partman/commit/180db75aee4fb92f508c8ff2824b3264e8f2b13c#diff-75bc84e34ecbf5ac4f364b3031718978b08b556b0821256d72b796c638e76c11R249).

I don't think this is locking anything, since it expands to

```
WHERE v_partition_expression >= v_min_partition_timestamp AND v_partition_expression < v_min_partition_timestamp
```

This PR makes it expand to 
```
WHERE v_partition_expression >= v_min_partition_timestamp AND v_partition_expression < v_max_partition_timestamp
```