### PR TITLE
Allow overriding of pg_config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ EXTENSION = pg_partman
 EXTVERSION = $(shell grep default_version $(EXTENSION).control | \
                sed -e "s/default_version[[:space:]]*=[[:space:]]*'\([^']*\)'/\1/")
 
-PG_CONFIG = pg_config
+PG_CONFIG ?= pg_config
 PG_VER = $(shell $(PG_CONFIG) --version | sed "s/^[^ ]* \([0-9]*\).*$$/\1/" 2>/dev/null)
 
 PG_VER_min = 14


### PR DESCRIPTION
Allow user to override the pg_config using in Makefile. For example:

```bash
PG_CONFIG=/path/to/my/pg_config make install
```

@keithf4 , maybe there's a way to do this already? Some other C based Postgres extensions allow this, e.g. [pg_cron](https://github.com/citusdata/pg_cron/blob/a8cb0e0b5018cf82e5a90728a91d04fb79594642/Makefile#L22) and [pgvector](https://github.com/pgvector/pgvector/blob/69a2ce0d432f45f24186ce7ef1683ab9af5329df/Makefile#L46)
