### PR TITLE
Qualify partition_gap_fill with @extschema@

### DIFF
--- a/sql/functions/partition_gap_fill.sql
+++ b/sql/functions/partition_gap_fill.sql
@@ -1,4 +1,4 @@
-CREATE FUNCTION partition_gap_fill(p_parent_table text) RETURNS integer
+CREATE FUNCTION @extschema@.partition_gap_fill(p_parent_table text) RETURNS integer
     LANGUAGE plpgsql
     AS $$
 DECLARE

--- a/updates/pg_partman--4.2.2--4.3.0.sql
+++ b/updates/pg_partman--4.2.2--4.3.0.sql
@@ -2003,7 +2003,7 @@ END
 $$;
 
 
-CREATE FUNCTION partition_gap_fill(p_parent_table text) RETURNS integer
+CREATE FUNCTION @extschema@.partition_gap_fill(p_parent_table text) RETURNS integer
     LANGUAGE plpgsql 
     AS $$
 DECLARE

--- a/updates/pg_partman--4.7.4--4.8.0.sql
+++ b/updates/pg_partman--4.7.4--4.8.0.sql
@@ -2,7 +2,7 @@
 
 DROP FUNCTION IF EXISTS @extschema@.partition_gap_fill(text);
 
-CREATE FUNCTION partition_gap_fill(p_parent_table text, p_analyze boolean DEFAULT true) RETURNS integer
+CREATE FUNCTION @extschema@.partition_gap_fill(p_parent_table text, p_analyze boolean DEFAULT true) RETURNS integer
     LANGUAGE plpgsql
     AS $$
 DECLARE

--- a/updates/pg_partman--5.0.1--5.1.0-beta.sql
+++ b/updates/pg_partman--5.0.1--5.1.0-beta.sql
@@ -3381,7 +3381,7 @@ $$;
 
 
 -- Drop and restore gapfill function to remove analyze parameter added in version 4.8
-CREATE FUNCTION partition_gap_fill(p_parent_table text) RETURNS integer
+CREATE FUNCTION @extschema@.partition_gap_fill(p_parent_table text) RETURNS integer
     LANGUAGE plpgsql
     AS $$
 DECLARE


### PR DESCRIPTION
I tried to install the extension to a new schema `partman5` so it can coexist with an older version under schema `partman` with commands like

    make
    sed -i -E 's/@extschema@/partman5/' sql/pg_partman--5.0.1.sql
    psql -U user db <sql/pg_partman--5.0.1.sql

but the install failed to create the function `partition_gap_fill` because it already exists.
I am _guessing_ that the function should be put in the `@extschema@` like other functions.