### PR TITLE
Add CI test and PGXN release workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+on:
+  push:
+    branches: ['*']
+  pull_request:
+  schedule:
+    - cron:  '0 12 5 * *' # Monthly at noon on the fifth
+jobs:
+  build:
+    strategy:
+      matrix:
+        pg: [17, 16, 15, 14]
+    name: 🐘 PostgreSQL ${{ matrix.pg }}
+    runs-on: ubuntu-latest
+    container: pgxn/pgxn-tools
+    steps:
+      - run: CREATE_OPTIONS="--pgoption max_locks_per_transaction=128" pg-start ${{ matrix.pg }} postgresql-${{ matrix.pg }}-pgtap
+      - uses: actions/checkout@v4
+      - run: make install
+      - run: psql -U postgres -c 'CREATE SCHEMA partman; CREATE EXTENSION pg_partman SCHEMA partman; CREATE EXTENSION pgtap'
+      - run: pg_prove --username postgres --ext .sql --comments --verbose --failures test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,20 @@
+name: Release
+on:
+  push:
+    tags: [v*]
+jobs:
+  release:
+    name: Release on PGXN
+    runs-on: ubuntu-latest
+    container: pgxn/pgxn-tools
+    env:
+      PGXN_USERNAME: ${{ secrets.PGXN_USERNAME }}
+      PGXN_PASSWORD: ${{ secrets.PGXN_PASSWORD }}
+    steps:
+    - name: Check out the repo
+      uses: actions/checkout@v4
+    - name: Bundle the Release
+      id: bundle
+      run: pgxn-bundle
+    - name: Release on PGXN
+      run: pgxn-release

--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,8 @@ ignore/*
 .deps/*
 *.o
 *.so
+*.bc
+*.dylib
 sql/*.sql
 test/not_working_yet/*
+*.zip

--- a/META.json
+++ b/META.json
@@ -11,7 +11,7 @@
     "prereqs": {
         "runtime": {
             "requires": {
-                "PostgreSQL": "14.0"
+                "PostgreSQL": "14.0.0"
             },
             "recommends": {
                 "pg_jobmon": "1.4.1"


### PR DESCRIPTION
Also ignore bitcode and darwin dylib files, and make the PostgreSQL version a valid SemVer in `META.json`.

Note that there are some test failures on PostgreSQL 17, as in [this run](/theory/pg_partman/actions/runs/9864934225/job/27240894696). I can remove testing on 17 for now if you'd like.

To make a release, you'll need to set the `PGXN_USERNAME` and `PGXN_PASSWORD` secrets in your project [here](https://github.com/pgpartman/pg_partman/settings/secrets/actions) and then push a tag with the semver for the release. To make a release without a tag, comment-out the `tags: [v*]` line in `release.yml`, push, wait for it to succeed, then restore that line to only release on tags in the future.