### PR TITLE
Refactor partition suffix logic to allow custom child prefixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+5.6.0
+=====
+NEW FEATURES
+------------
+ - Allow a custom prefix to be used between the parent table name and the partition suffix when naming child tables, instead of the hardcoded `_p`. A new `part_config` column, `child_table_prefix`, controls this and defaults to `_p` to preserve existing behavior for all current partition sets. Set it with `UPDATE part_config SET child_table_prefix = '...' WHERE parent_table = ...` after the partition set is created (like other options not exposed directly on `create_parent()`/`create_partition()`). Takes effect on all subsequently created child tables (`run_maintenance()`, `create_partition_time()`/`create_partition_id()`, `partition_data_time()`/`partition_data_id()`, and `show_partition_name()`); existing child tables are not renamed.
+
+
 5.5.0
 =====
 BREAKING CHANGES

--- a/META.json
+++ b/META.json
@@ -1,7 +1,7 @@
 {
     "name": "pg_partman",
     "abstract": "Extension to manage partitioned tables by time or ID",
-    "version": "5.5.0",
+    "version": "5.6.0",
     "maintainer": [
         "Keith Fiske <keith@keithf4.com>"
     ],
@@ -20,9 +20,9 @@
     },
     "provides": {
         "pg_partman": {
-            "file": "sql/pg_partman--5.5.0.sql",
+            "file": "sql/pg_partman--5.6.0.sql",
             "docfile": "doc/pg_partman.md",
-            "version": "5.5.0",
+            "version": "5.6.0",
             "abstract": "Extension to manage partitioned tables by time or ID"
         }
     },

--- a/doc/pg_partman.md
+++ b/doc/pg_partman.md
@@ -841,6 +841,7 @@ Stores all configuration data for partition sets managed by the extension.
     , retention_keep_publication boolean NOT NULL DEFAULT false
     , maintenance_last_run timestamptz
     , async_partitioning_in_progress text
+    , child_table_prefix text NOT NULL DEFAULT '_p'
 
  - `parent_table`
     - Parent table of the partition set
@@ -909,6 +910,10 @@ Stores all configuration data for partition sets managed by the extension.
     - Timestamp of the last successful run of maintenance for this partition set. Can be useful as a monitoring metric to ensure partition maintenance is running properly.
  - async_partitioning_in_progress
     - This column is used to track if an asynchronous partitioning process has been started. It is a text field that contains the value related to the last block of data that was processed. If NOT NULL, all regular maintenance for this table will be stopped until the async partitioning process has been completed successfully. See `partition_data_async()` for more information.
+ - `child_table_prefix`
+    - Text value placed between the parent table name and the partition suffix when naming child tables. Defaults to `_p` to preserve existing naming for all current partition sets.
+    - Can be set to any non-empty string (Ex: `_` for a shorter naming convention, or any other custom value). Empty string is not allowed.
+    - Cannot be set at `create_parent()`/`create_partition()` time. Set it afterwards with `UPDATE part_config SET child_table_prefix = '...' WHERE parent_table = ...`. Takes effect for all child tables created after the update (via `run_maintenance()`, direct calls to `create_partition_time()`/`create_partition_id()`, or `partition_data_time()`/`partition_data_id()`); existing child tables are not renamed.
 
 
 <a id="part_config_sub"></a>

--- a/pg_partman.control
+++ b/pg_partman.control
@@ -1,4 +1,4 @@
-default_version = '5.5.0'
+default_version = '5.6.0'
 comment = 'Extension to manage partitioned tables by time or ID'
 relocatable = false
 superuser = false

--- a/sql/functions/check_name_length.sql
+++ b/sql/functions/check_name_length.sql
@@ -2,7 +2,7 @@ CREATE FUNCTION @extschema@.check_name_length (
     p_object_name text
     , p_suffix text DEFAULT NULL
     , p_table_partition boolean DEFAULT FALSE
-    , p_simple_naming boolean DEFAULT FALSE
+    , p_partition_prefix text DEFAULT '_p'
 )
     RETURNS text
     LANGUAGE plpgsql IMMUTABLE
@@ -16,6 +16,7 @@ BEGIN
  * Truncate the name of the given object if it is greater than the postgres default max (63 bytes).
  * Also appends given suffix and schema if given and truncates the name so that the entire suffix will fit.
  * Returns original name (with suffix if given) if it doesn't require truncation
+ * p_partition_prefix allows callers to override the default '_p' prefix placed between the object name and suffix (Ex: part_config.child_table_prefix)
  */
 
 IF p_table_partition IS TRUE AND (NULLIF(p_suffix, '') IS NULL) THEN
@@ -23,14 +24,7 @@ IF p_table_partition IS TRUE AND (NULLIF(p_suffix, '') IS NULL) THEN
 END IF;
 
 
-v_suffix := format('%s%s',
-    CASE
-        WHEN p_table_partition AND p_simple_naming THEN '_'
-        WHEN p_table_partition THEN '_p'
-    END,
-    p_suffix
-);
-
+v_suffix := format('%s%s', CASE WHEN p_table_partition THEN p_partition_prefix END, p_suffix);
 -- Use optimistic behavior: in almost all cases `v_new_name` will be less than allowed maximum.
 -- Do "heavy" work only in rare cases.
 v_new_name := p_object_name || v_suffix;

--- a/sql/functions/check_name_length.sql
+++ b/sql/functions/check_name_length.sql
@@ -2,6 +2,7 @@ CREATE FUNCTION @extschema@.check_name_length (
     p_object_name text
     , p_suffix text DEFAULT NULL
     , p_table_partition boolean DEFAULT FALSE
+    , p_simple_naming boolean DEFAULT FALSE
 )
     RETURNS text
     LANGUAGE plpgsql IMMUTABLE
@@ -22,7 +23,14 @@ IF p_table_partition IS TRUE AND (NULLIF(p_suffix, '') IS NULL) THEN
 END IF;
 
 
-v_suffix := format('%s%s', CASE WHEN p_table_partition THEN '_p' END, p_suffix);
+v_suffix := format('%s%s',
+    CASE
+        WHEN p_table_partition AND p_simple_naming THEN '_'
+        WHEN p_table_partition THEN '_p'
+    END,
+    p_suffix
+);
+
 -- Use optimistic behavior: in almost all cases `v_new_name` will be less than allowed maximum.
 -- Do "heavy" work only in rare cases.
 v_new_name := p_object_name || v_suffix;

--- a/sql/functions/create_partition_id.sql
+++ b/sql/functions/create_partition_id.sql
@@ -13,6 +13,7 @@ ex_context                      text;
 ex_detail                       text;
 ex_hint                         text;
 ex_message                      text;
+v_child_table_prefix            text;
 v_control                       text;
 v_control_type                  text;
 v_exists                        text;
@@ -51,12 +52,14 @@ SELECT control
     , jobmon
     , template_table
     , inherit_privileges
+    , child_table_prefix
 INTO v_control
     , v_partition_interval
     , v_partition_type
     , v_jobmon
     , v_template_table
     , v_inherit_privileges
+    , v_child_table_prefix
 FROM @extschema@.part_config
 WHERE parent_table = p_parent_table;
 
@@ -109,7 +112,7 @@ FOREACH v_id IN ARRAY p_partition_ids LOOP
         END IF;
     END IF;
 
-    v_partition_name := @extschema@.check_name_length(v_parent_tablename, v_id::text, TRUE);
+    v_partition_name := @extschema@.check_name_length(v_parent_tablename, v_id::text, TRUE, v_child_table_prefix);
     -- If child table already exists, skip creation
     -- Have to check pg_class because if subpartitioned, table will not be in pg_tables
     SELECT c.relname INTO v_exists

--- a/sql/functions/create_partition_time.sql
+++ b/sql/functions/create_partition_time.sql
@@ -13,6 +13,7 @@ ex_context                      text;
 ex_detail                       text;
 ex_hint                         text;
 ex_message                      text;
+v_child_table_prefix            text;
 v_control                       text;
 v_control_type                  text;
 v_datetime_string               text;
@@ -63,6 +64,7 @@ SELECT control
     , datetime_string
     , template_table
     , inherit_privileges
+    , child_table_prefix
 INTO v_control
     , v_time_encoder
     , v_partition_interval
@@ -71,6 +73,7 @@ INTO v_control
     , v_datetime_string
     , v_template_table
     , v_inherit_privileges
+    , v_child_table_prefix
 FROM @extschema@.part_config
 WHERE parent_table = p_parent_table;
 
@@ -152,7 +155,7 @@ FOREACH v_time IN ARRAY p_partition_times LOOP
 
     -- This suffix generation code is in partition_data_time() as well
     v_partition_suffix := to_char(v_time, v_datetime_string);
-    v_partition_name := @extschema@.check_name_length(v_parent_tablename, v_partition_suffix, TRUE);
+    v_partition_name := @extschema@.check_name_length(v_parent_tablename, v_partition_suffix, TRUE, v_child_table_prefix);
     -- Check if child exists.
     SELECT count(*) INTO v_exists
     FROM pg_catalog.pg_class c

--- a/sql/functions/dump_partitioned_table_definition.sql
+++ b/sql/functions/dump_partitioned_table_definition.sql
@@ -9,6 +9,7 @@ CREATE FUNCTION @extschema@.dump_partitioned_table_definition(
 DECLARE
     v_automatic_maintenance text;
     v_create_partition_definition text;
+    v_child_table_prefix text;
     v_constraint_cols TEXT[];
     v_constraint_valid boolean;
     v_control text;
@@ -69,6 +70,7 @@ BEGIN
         , pc.retention_keep_publication
         , pc.detach_before_drop
         , pc.maintenance_role
+        , pc.child_table_prefix
     INTO
         v_parent_table
         , v_control
@@ -96,6 +98,7 @@ BEGIN
         , v_retention_keep_publication
         , v_detach_before_drop
         , v_maintenance_role
+        , v_child_table_prefix
     FROM @extschema@.part_config pc
     WHERE pc.parent_table = p_parent_table;
 
@@ -185,7 +188,8 @@ E'UPDATE @extschema@.part_config SET
 \tmaintenance_order = %L,
 \tretention_keep_publication = %L,
 \tdetach_before_drop = %L,
-\tmaintenance_role = %L
+\tmaintenance_role = %L,
+\tchild_table_prefix = %L
 WHERE parent_table = %L;',
         v_optimize_constraint
         , v_retention
@@ -202,6 +206,7 @@ WHERE parent_table = %L;',
         , v_retention_keep_publication
         , v_detach_before_drop
         , v_maintenance_role
+        , v_child_table_prefix
         , v_parent_table
     );
 

--- a/sql/functions/partition_data_id.sql
+++ b/sql/functions/partition_data_id.sql
@@ -16,6 +16,7 @@ CREATE FUNCTION @extschema@.partition_data_id(
 DECLARE
 
 v_analyze                   boolean := FALSE;
+v_child_table_prefix        text;
 v_column_list_filtered      text;
 v_column_list_full          text;
 v_control                   text;
@@ -49,9 +50,11 @@ BEGIN
     SELECT partition_interval::bigint
     , control
     , epoch
+    , child_table_prefix
     INTO v_partition_interval
     , v_control
     , v_epoch
+    , v_child_table_prefix
     FROM @extschema@.part_config
     WHERE parent_table = p_parent_table;
     IF NOT FOUND THEN
@@ -199,7 +202,7 @@ FOR i IN 1..p_batch_count LOOP
         END IF;
     END IF;
 
-    v_current_partition_name := @extschema@.check_name_length(COALESCE(v_parent_tablename), v_min_partition_id::text, TRUE);
+    v_current_partition_name := @extschema@.check_name_length(COALESCE(v_parent_tablename), v_min_partition_id::text, TRUE, v_child_table_prefix);
 
     IF p_override_system_value THEN
         v_override_statement = ' OVERRIDING SYSTEM VALUE ';

--- a/sql/functions/partition_data_time.sql
+++ b/sql/functions/partition_data_time.sql
@@ -18,6 +18,7 @@ DECLARE
 
 v_analyze                   boolean := FALSE;
 v_async_rowcount            int;
+v_child_table_prefix        text;
 v_column_list_filtered      text;
 v_column_list_full          text;
 v_control                   text;
@@ -65,12 +66,14 @@ SELECT partition_interval::interval
     , time_decoder
     , datetime_string
     , epoch
+    , child_table_prefix
 INTO v_partition_interval
     , v_control
     , v_time_encoder
     , v_time_decoder
     , v_datetime_string
     , v_epoch
+    , v_child_table_prefix
 FROM @extschema@.part_config
 WHERE parent_table = p_parent_table;
 IF NOT FOUND THEN
@@ -305,7 +308,7 @@ FOR i IN 1..p_batch_count LOOP
 
     -- This suffix generation code is in create_partition_time() as well
     v_partition_suffix := to_char(v_min_partition_timestamp, v_datetime_string);
-    v_current_partition_name := @extschema@.check_name_length(v_parent_tablename, v_partition_suffix, TRUE);
+    v_current_partition_name := @extschema@.check_name_length(v_parent_tablename, v_partition_suffix, TRUE, v_child_table_prefix);
 
     IF p_override_system_value THEN
         v_override_statement = ' OVERRIDING SYSTEM VALUE ';

--- a/sql/functions/show_partition_name.sql
+++ b/sql/functions/show_partition_name.sql
@@ -17,6 +17,7 @@ v_child_exists                  text;
 v_child_larger                  boolean := false;
 v_child_smaller                 boolean := false;
 v_child_start_time              timestamptz;
+v_child_table_prefix            text;
 v_control                       text;
 v_time_encoder                  text;
 v_control_type                  text;
@@ -42,12 +43,14 @@ SELECT partition_type
     , partition_interval
     , datetime_string
     , epoch
+    , child_table_prefix
 INTO v_type
     , v_control
     , v_time_encoder
     , v_partition_interval
     , v_datetime_string
     , v_epoch
+    , v_child_table_prefix
 FROM @extschema@.part_config
 WHERE parent_table = p_parent_table;
 
@@ -126,11 +129,11 @@ IF (v_control_type IN ('time', 'text', 'uuid') OR (v_control_type = 'id' AND v_e
         END LOOP;
     END IF;
 
-    partition_table := @extschema@.check_name_length(v_parent_tablename, to_char(suffix_timestamp, v_datetime_string), TRUE);
+    partition_table := @extschema@.check_name_length(v_parent_tablename, to_char(suffix_timestamp, v_datetime_string), TRUE, v_child_table_prefix);
 
 ELSIF v_control_type = 'id' THEN
     suffix_id := (p_value::bigint - (p_value::bigint % v_partition_interval::bigint));
-    partition_table := @extschema@.check_name_length(v_parent_tablename, suffix_id::text, TRUE);
+    partition_table := @extschema@.check_name_length(v_parent_tablename, suffix_id::text, TRUE, v_child_table_prefix);
 
 ELSE
     RAISE EXCEPTION 'Unexpected code path encountered in show_partition_name(). No valid control type found. Please report this issue to author with relevant partition config info.';

--- a/sql/tables/tables.sql
+++ b/sql/tables/tables.sql
@@ -30,8 +30,10 @@ CREATE TABLE @extschema@.part_config (
     , detach_before_drop BOOLEAN DEFAULT false
     , maintenance_role TEXT DEFAULT current_user
     , async_partitioning_in_progress text
+    , child_table_prefix text NOT NULL DEFAULT '_p'
     , CONSTRAINT part_config_parent_table_pkey PRIMARY KEY (parent_table)
     , CONSTRAINT positive_premake_check CHECK (premake > 0)
+    , CONSTRAINT child_table_prefix_not_empty_chk CHECK (child_table_prefix <> '')
 );
 
 CREATE INDEX part_config_type_idx ON @extschema@.part_config (partition_type);

--- a/test/test-child-table-prefix-id.sql
+++ b/test/test-child-table-prefix-id.sql
@@ -1,0 +1,41 @@
+-- ########## CUSTOM CHILD TABLE PREFIX TESTS (ID) ##########
+-- Covers part_config.child_table_prefix and its plumbing through
+-- create_partition_id(), show_partition_name(), and partition_data_id().
+
+\set ON_ERROR_ROLLBACK 1
+\set ON_ERROR_STOP true
+
+BEGIN;
+SELECT set_config('search_path','partman, public',false);
+
+SELECT plan(5);
+CREATE SCHEMA partman_test;
+
+CREATE TABLE partman_test.id_prefix_table (col1 bigint PRIMARY KEY) PARTITION BY RANGE (col1);
+
+SELECT create_partition('partman_test.id_prefix_table', 'col1', '10', p_start_partition := '100', p_premake := 1);
+
+-- Default behavior (child_table_prefix defaults to '_p') is unaffected by this feature
+SELECT has_table('partman_test', 'id_prefix_table_p100', 'Default prefix (_p) still used for initial partition creation');
+
+UPDATE part_config SET child_table_prefix = '_batch_' WHERE parent_table = 'partman_test.id_prefix_table';
+
+-- create_partition_id() should now use the custom prefix
+SELECT create_partition_id('partman_test.id_prefix_table', ARRAY[200]::bigint[]);
+SELECT has_table('partman_test', 'id_prefix_table_batch_200', 'create_partition_id() uses custom child_table_prefix');
+SELECT hasnt_table('partman_test', 'id_prefix_table_p200', 'create_partition_id() does not fall back to the default _p prefix once customized');
+
+-- show_partition_name() should reflect the custom prefix
+SELECT results_eq(
+    E'SELECT (show_partition_name(''partman_test.id_prefix_table'', ''205'')).partition_table',
+    ARRAY['id_prefix_table_batch_200'],
+    'show_partition_name() reflects custom child_table_prefix for id partitioning'
+);
+
+-- partition_data_id() should also honor the custom prefix when moving default data into a new child
+INSERT INTO partman_test.id_prefix_table (col1) VALUES (300);
+SELECT partition_data_id('partman_test.id_prefix_table');
+SELECT has_table('partman_test', 'id_prefix_table_batch_300', 'partition_data_id() uses custom child_table_prefix when creating the child table');
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/test/test-child-table-prefix-time.sql
+++ b/test/test-child-table-prefix-time.sql
@@ -1,0 +1,59 @@
+-- ########## CUSTOM CHILD TABLE PREFIX TESTS (TIME) ##########
+-- Covers part_config.child_table_prefix and its plumbing through
+-- create_partition_time(), show_partition_name(), partition_data_time(),
+-- and the not-empty check constraint.
+
+\set ON_ERROR_ROLLBACK 1
+\set ON_ERROR_STOP true
+
+BEGIN;
+SELECT set_config('search_path','partman, public',false);
+
+SELECT plan(7);
+CREATE SCHEMA partman_test;
+
+CREATE TABLE partman_test.time_prefix_table (
+    col1 int
+    , col2 timestamptz NOT NULL DEFAULT now())
+    PARTITION BY RANGE (col2);
+
+SELECT create_partition('partman_test.time_prefix_table', 'col2', '1 day', p_premake := 1, p_start_partition := CURRENT_DATE::text);
+
+-- Default behavior (child_table_prefix defaults to '_p') is unaffected by this feature
+SELECT has_table('partman_test', 'time_prefix_table_p'||to_char(CURRENT_DATE, 'YYYYMMDD'),
+    'Default prefix (_p) still used for initial partition creation');
+
+UPDATE part_config SET child_table_prefix = '_' WHERE parent_table = 'partman_test.time_prefix_table';
+
+-- create_partition_time() should now use the custom prefix
+SELECT create_partition_time('partman_test.time_prefix_table', ARRAY[(CURRENT_DATE + '5 days'::interval)]::timestamptz[]);
+SELECT has_table('partman_test', 'time_prefix_table_'||to_char(CURRENT_DATE + '5 days'::interval, 'YYYYMMDD'),
+    'create_partition_time() uses custom child_table_prefix');
+SELECT hasnt_table('partman_test', 'time_prefix_table_p'||to_char(CURRENT_DATE + '5 days'::interval, 'YYYYMMDD'),
+    'create_partition_time() does not fall back to the default _p prefix once customized');
+
+-- show_partition_name() should reflect the custom prefix
+SELECT results_eq(
+    E'SELECT (show_partition_name(''partman_test.time_prefix_table'', (CURRENT_DATE + ''5 days''::interval)::text)).partition_table',
+    ARRAY['time_prefix_table_'||to_char(CURRENT_DATE + '5 days'::interval, 'YYYYMMDD')],
+    'show_partition_name() reflects custom child_table_prefix'
+);
+
+-- partition_data_time() should also honor the custom prefix when moving default data into a new child
+INSERT INTO partman_test.time_prefix_table (col1, col2) VALUES (1, CURRENT_DATE + '6 days'::interval);
+SELECT is_empty('SELECT * FROM ONLY partman_test.time_prefix_table', 'Data outside any existing child goes to the default partition');
+SELECT partition_data_time('partman_test.time_prefix_table');
+SELECT has_table('partman_test', 'time_prefix_table_'||to_char(CURRENT_DATE + '6 days'::interval, 'YYYYMMDD'),
+    'partition_data_time() uses custom child_table_prefix when creating the child table');
+
+-- ##### CONSTRAINT #####
+
+SELECT throws_ok(
+    $$UPDATE part_config SET child_table_prefix = '' WHERE parent_table = 'partman_test.time_prefix_table'$$,
+    '23514',
+    NULL,
+    'Empty child_table_prefix is rejected by check constraint'
+);
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/test/test-dump-definition.sql
+++ b/test/test-dump-definition.sql
@@ -46,7 +46,8 @@ SELECT bag_eq(
     'maintenance_last_run',
     'async_partitioning_in_progress',
     'detach_before_drop',
-    'maintenance_role'
+    'maintenance_role',
+    'child_table_prefix'
   ]::TEXT[],
   'When adding a new column to part_config please ensure it is also added to the dump_partitioned_table_definition function and the tests in this file'
 );
@@ -102,7 +103,8 @@ UPDATE partman.part_config SET
 	maintenance_order = NULL,
 	retention_keep_publication = ''f'',
 	detach_before_drop = ''f'',
-	maintenance_role = '''|| current_user ||'''
+	maintenance_role = '''|| current_user ||''',
+	child_table_prefix = ''_p''
 WHERE parent_table = ''partman_test.declarative_objects'';'
 );
 

--- a/updates/pg_partman--5.5.0--5.6.0.sql
+++ b/updates/pg_partman--5.5.0--5.6.0.sql
@@ -1,0 +1,1884 @@
+ALTER TABLE @extschema@.part_config ADD COLUMN child_table_prefix text NOT NULL DEFAULT '_p';
+ALTER TABLE @extschema@.part_config ADD CONSTRAINT child_table_prefix_not_empty_chk CHECK (child_table_prefix <> '');
+
+CREATE OR REPLACE FUNCTION @extschema@.check_name_length (
+    p_object_name text
+    , p_suffix text DEFAULT NULL
+    , p_table_partition boolean DEFAULT FALSE
+    , p_partition_prefix text DEFAULT '_p'
+)
+    RETURNS text
+    LANGUAGE plpgsql IMMUTABLE
+    SET search_path TO pg_catalog, pg_temp
+    AS $$
+DECLARE
+    v_new_name      text;
+    v_suffix        text;
+BEGIN
+/*
+ * Truncate the name of the given object if it is greater than the postgres default max (63 bytes).
+ * Also appends given suffix and schema if given and truncates the name so that the entire suffix will fit.
+ * Returns original name (with suffix if given) if it doesn't require truncation
+ * p_partition_prefix allows callers to override the default '_p' prefix placed between the object name and suffix (Ex: part_config.child_table_prefix)
+ */
+
+IF p_table_partition IS TRUE AND (NULLIF(p_suffix, '') IS NULL) THEN
+    RAISE EXCEPTION 'Table partition name requires a suffix value';
+END IF;
+
+
+v_suffix := format('%s%s', CASE WHEN p_table_partition THEN p_partition_prefix END, p_suffix);
+-- Use optimistic behavior: in almost all cases `v_new_name` will be less than allowed maximum.
+-- Do "heavy" work only in rare cases.
+v_new_name := p_object_name || v_suffix;
+
+-- Postgres' relation name limit is in bytes, not characters; also it can be compiled with bigger allowed length.
+-- Use its internals to detect where to cut new object name.
+IF v_new_name::name != v_new_name THEN
+    -- Here we need to detect how many chars (not bytes) we need to get from the `p_object_name`.
+    -- Use suffix as prefix and get the rest of `p_object_name`.
+    v_new_name := (v_suffix || p_object_name)::name;
+    -- `substr` starts from 1, that is why we need to add 1 below.
+    -- Edge case: `v_suffix` is empty, length is 0, but need to start from 1.
+    v_new_name := substr(v_new_name, length(v_suffix) + 1) || v_suffix;
+END IF;
+
+RETURN v_new_name;
+
+END
+$$;
+
+
+CREATE OR REPLACE FUNCTION @extschema@.create_partition_time(
+    p_parent_table text
+    , p_partition_times timestamptz[]
+    , p_start_partition text DEFAULT NULL
+)
+    RETURNS boolean
+    LANGUAGE plpgsql
+    SET search_path = @extschema@, pg_catalog, pg_temp
+    AS $$
+DECLARE
+
+ex_context                      text;
+ex_detail                       text;
+ex_hint                         text;
+ex_message                      text;
+v_child_table_prefix            text;
+v_control                       text;
+v_control_type                  text;
+v_datetime_string               text;
+v_epoch                         text;
+v_exists                        smallint;
+v_inherit_privileges            boolean;
+v_job_id                        bigint;
+v_jobmon                        boolean;
+v_jobmon_schema                 text;
+v_new_search_path               text;
+v_old_search_path               text;
+v_parent_oid                    oid;
+v_parent_schema                 text;
+v_parent_tablename              text;
+v_parent_tablespace             name;
+v_partition_created             boolean := false;
+v_partition_name                text;
+v_partition_suffix              text;
+v_partition_expression          text;
+v_partition_interval            interval;
+v_partition_timestamp_end       timestamptz;
+v_partition_timestamp_start     timestamptz;
+v_row                           record;
+v_sql                           text;
+v_step_id                       bigint;
+v_step_overflow_id              bigint;
+v_sub_control                   text;
+v_sub_partition_type            text;
+v_sub_timestamp_max             timestamptz;
+v_sub_timestamp_min             timestamptz;
+v_template_table                text;
+v_time                          timestamptz;
+v_time_encoder                  text;
+v_time_encoder_safe             text;
+v_partition_text_start          text;
+v_partition_text_end            text;
+
+BEGIN
+/*
+ * Function to create a child table in a time-based partition set
+ */
+
+SELECT control
+    , time_encoder
+    , partition_interval::interval -- this shared field also used in partition_id as bigint
+    , epoch
+    , jobmon
+    , datetime_string
+    , template_table
+    , inherit_privileges
+    , child_table_prefix
+INTO v_control
+    , v_time_encoder
+    , v_partition_interval
+    , v_epoch
+    , v_jobmon
+    , v_datetime_string
+    , v_template_table
+    , v_inherit_privileges
+    , v_child_table_prefix
+FROM @extschema@.part_config
+WHERE parent_table = p_parent_table;
+
+IF NOT FOUND THEN
+    RAISE EXCEPTION 'ERROR: no config found for %', p_parent_table;
+END IF;
+
+SELECT n.nspname
+    , c.relname
+    , c.oid
+    , t.spcname
+INTO v_parent_schema
+    , v_parent_tablename
+    , v_parent_oid
+    , v_parent_tablespace
+FROM pg_catalog.pg_class c
+JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
+LEFT OUTER JOIN pg_catalog.pg_tablespace t ON c.reltablespace = t.oid
+WHERE n.nspname = split_part(p_parent_table, '.', 1)::name
+AND c.relname = split_part(p_parent_table, '.', 2)::name;
+
+SELECT general_type INTO v_control_type FROM @extschema@.check_control_type(v_parent_schema, v_parent_tablename, v_control);
+IF v_control_type <> 'time' THEN
+    IF (v_control_type = 'id' AND v_epoch = 'none') OR v_control_type NOT IN ('text', 'id', 'uuid') OR (v_control_type IN ('text', 'uuid') AND v_time_encoder IS NULL) THEN
+        RAISE EXCEPTION 'Cannot run on partition set without time based control column, an epoch flag set with an id column or time_encoder set with text column. Found control: %, epoch: %, time_encoder: %s', v_control_type, v_epoch, v_time_encoder;
+    END IF;
+END IF;
+
+IF v_jobmon THEN
+    SELECT nspname INTO v_jobmon_schema FROM pg_catalog.pg_namespace n, pg_catalog.pg_extension e WHERE e.extname = 'pg_jobmon'::name AND e.extnamespace = n.oid;
+    IF v_jobmon_schema IS NOT NULL THEN
+        SELECT current_setting('search_path') INTO v_old_search_path;
+        IF v_jobmon_schema IS NOT NULL THEN
+            v_new_search_path := format('%s,%s',v_jobmon_schema, v_old_search_path);
+            EXECUTE format('SET LOCAL search_path TO %s', v_new_search_path);
+        END IF;
+    END IF;
+END IF;
+
+-- Determine if this table is a child of a subpartition parent. If so, get limits of what child tables can be created based on parent suffix
+SELECT sub_min::timestamptz, sub_max::timestamptz INTO v_sub_timestamp_min, v_sub_timestamp_max FROM @extschema@.check_subpartition_limits(p_parent_table, 'time');
+
+IF v_jobmon_schema IS NOT NULL THEN
+    v_job_id := add_job(format('PARTMAN CREATE TABLE: %s', p_parent_table));
+END IF;
+
+v_partition_expression := CASE
+    WHEN v_epoch = 'seconds' THEN format('to_timestamp(%I)', v_control)
+    WHEN v_epoch = 'milliseconds' THEN format('to_timestamp((%I/1000)::float)', v_control)
+    WHEN v_epoch = 'microseconds' THEN format('to_timestamp((%I/1000000)::float)', v_control)
+    WHEN v_epoch = 'nanoseconds' THEN format('to_timestamp((%I/1000000000)::float)', v_control)
+    ELSE format('%I', v_control)
+END;
+RAISE DEBUG 'create_partition_time: v_partition_expression: %', v_partition_expression;
+
+FOREACH v_time IN ARRAY p_partition_times LOOP
+    v_partition_timestamp_start := v_time;
+    BEGIN
+        v_partition_timestamp_end := v_time + v_partition_interval;
+    EXCEPTION WHEN datetime_field_overflow THEN
+        RAISE WARNING 'Attempted partition time interval is outside PostgreSQL''s supported time range.
+            Child partition creation after time % skipped', v_time;
+        v_step_overflow_id := add_step(v_job_id, 'Attempted partition time interval is outside PostgreSQL''s supported time range.');
+        PERFORM update_step(v_step_overflow_id, 'CRITICAL', 'Child partition creation after time '||v_time||' skipped');
+
+        CONTINUE;
+    END;
+
+    -- Do not create the child table if it's outside the bounds of the top parent.
+    IF v_sub_timestamp_min IS NOT NULL THEN
+        IF v_time < v_sub_timestamp_min OR v_time >= v_sub_timestamp_max THEN
+
+            RAISE DEBUG 'create_partition_time: p_parent_table: %, v_time: %, v_sub_timestamp_min: %, v_sub_timestamp_max: %'
+                    , p_parent_table, v_time, v_sub_timestamp_min, v_sub_timestamp_max;
+
+            CONTINUE;
+        END IF;
+    END IF;
+
+    -- This suffix generation code is in partition_data_time() as well
+    v_partition_suffix := to_char(v_time, v_datetime_string);
+    v_partition_name := @extschema@.check_name_length(v_parent_tablename, v_partition_suffix, TRUE, v_child_table_prefix);
+    -- Check if child exists.
+    SELECT count(*) INTO v_exists
+    FROM pg_catalog.pg_class c
+    JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
+    WHERE n.nspname = v_parent_schema::name
+    AND c.relname = v_partition_name::name;
+
+    IF v_exists > 0 THEN
+        CONTINUE;
+    END IF;
+
+    IF v_jobmon_schema IS NOT NULL THEN
+        v_step_id := add_step(v_job_id, format('Creating new partition %s.%s with interval from %s to %s'
+                                                , v_parent_schema
+                                                , v_partition_name
+                                                , v_partition_timestamp_start
+                                                , v_partition_timestamp_end-'1sec'::interval));
+    END IF;
+
+    v_sql := 'CREATE';
+
+
+    -- Same INCLUDING list is used in create_partition()
+    v_sql := v_sql || format(' TABLE %I.%I (LIKE %I.%I INCLUDING COMMENTS INCLUDING COMPRESSION INCLUDING CONSTRAINTS INCLUDING DEFAULTS INCLUDING GENERATED INCLUDING STATISTICS INCLUDING STORAGE) '
+                                , v_parent_schema
+                                , v_partition_name
+                                , v_parent_schema
+                                , v_parent_tablename);
+
+    IF v_parent_tablespace IS NOT NULL THEN
+        v_sql := format('%s TABLESPACE %I ', v_sql, v_parent_tablespace);
+    END IF;
+
+    SELECT sub_partition_type, sub_control INTO v_sub_partition_type, v_sub_control
+    FROM @extschema@.part_config_sub
+    WHERE sub_parent = p_parent_table;
+    IF v_sub_partition_type = 'range' THEN
+        v_sql :=  format('%s PARTITION BY RANGE (%I) ', v_sql, v_sub_control);
+    ELSIF v_sub_partition_type = 'list' THEN
+        v_sql := format('%s PARTITION BY LIST (%I) ', v_sql, v_sub_control);
+    END IF;
+
+    RAISE DEBUG 'create_partition_time v_sql: %', v_sql;
+    EXECUTE v_sql;
+
+    PERFORM @extschema@.inherit_parent_properties(v_parent_schema, v_parent_tablename, v_partition_name);
+
+    IF v_template_table IS NOT NULL THEN
+        PERFORM @extschema@.inherit_template_properties(p_parent_table, v_parent_schema, v_partition_name);
+    END IF;
+
+    IF v_epoch = 'none' THEN
+        -- Attach with normal, time-based values for built-in constraint
+        IF v_time_encoder IS NULL THEN
+            EXECUTE format('ALTER TABLE %I.%I ATTACH PARTITION %I.%I FOR VALUES FROM (%L) TO (%L)'
+                , v_parent_schema
+                , v_parent_tablename
+                , v_parent_schema
+                , v_partition_name
+                , v_partition_timestamp_start
+                , v_partition_timestamp_end);
+        ELSE
+            v_time_encoder_safe := partman_safe_obj_name(v_time_encoder);
+
+            EXECUTE format('SELECT %s(%L)', v_time_encoder_safe, v_partition_timestamp_start) INTO v_partition_text_start;
+            EXECUTE format('SELECT %s(%L)', v_time_encoder_safe, v_partition_timestamp_end) INTO v_partition_text_end;
+
+            EXECUTE format('ALTER TABLE %I.%I ATTACH PARTITION %I.%I FOR VALUES FROM (%L) TO (%L)'
+                , v_parent_schema
+                , v_parent_tablename
+                , v_parent_schema
+                , v_partition_name
+                , v_partition_text_start
+                , v_partition_text_end);
+        END IF;
+
+    ELSE
+        -- Must attach with integer based values for built-in constraint and epoch
+        IF v_epoch = 'seconds' THEN
+            EXECUTE format('ALTER TABLE %I.%I ATTACH PARTITION %I.%I FOR VALUES FROM (%L) TO (%L)'
+                , v_parent_schema
+                , v_parent_tablename
+                , v_parent_schema
+                , v_partition_name
+                , EXTRACT('epoch' FROM v_partition_timestamp_start)::bigint
+                , EXTRACT('epoch' FROM v_partition_timestamp_end)::bigint);
+        ELSIF v_epoch = 'milliseconds' THEN
+            EXECUTE format('ALTER TABLE %I.%I ATTACH PARTITION %I.%I FOR VALUES FROM (%L) TO (%L)'
+                , v_parent_schema
+                , v_parent_tablename
+                , v_parent_schema
+                , v_partition_name
+                , EXTRACT('epoch' FROM v_partition_timestamp_start)::bigint * 1000
+                , EXTRACT('epoch' FROM v_partition_timestamp_end)::bigint * 1000);
+        ELSIF v_epoch = 'microseconds' THEN
+            EXECUTE format('ALTER TABLE %I.%I ATTACH PARTITION %I.%I FOR VALUES FROM (%L) TO (%L)'
+                , v_parent_schema
+                , v_parent_tablename
+                , v_parent_schema
+                , v_partition_name
+                , EXTRACT('epoch' FROM v_partition_timestamp_start)::bigint * 1000000
+                , EXTRACT('epoch' FROM v_partition_timestamp_end)::bigint * 1000000);
+        ELSIF v_epoch = 'nanoseconds' THEN
+            EXECUTE format('ALTER TABLE %I.%I ATTACH PARTITION %I.%I FOR VALUES FROM (%L) TO (%L)'
+                , v_parent_schema
+                , v_parent_tablename
+                , v_parent_schema
+                , v_partition_name
+                , EXTRACT('epoch' FROM v_partition_timestamp_start)::bigint * 1000000000
+                , EXTRACT('epoch' FROM v_partition_timestamp_end)::bigint * 1000000000);
+        END IF;
+        -- Create secondary, time-based constraint since built-in's constraint is already integer based
+        EXECUTE format('ALTER TABLE %I.%I ADD CONSTRAINT %I CHECK (%s >= %L AND %4$s < %6$L)'
+            , v_parent_schema
+            , v_partition_name
+            , v_partition_name||'_partition_check'
+            , v_partition_expression
+            , v_partition_timestamp_start
+            , v_partition_timestamp_end);
+    END IF;
+
+    -- NOTE: Privileges not automatically inherited. Only do so if config flag is set
+    IF v_inherit_privileges = TRUE THEN
+        PERFORM @extschema@.apply_privileges(v_parent_schema, v_parent_tablename, v_parent_schema, v_partition_name, v_job_id);
+    END IF;
+
+    IF v_jobmon_schema IS NOT NULL THEN
+        PERFORM update_step(v_step_id, 'OK', 'Done');
+    END IF;
+
+    -- Will only loop once and only if sub_partitioning is actually configured
+    -- This seemed easier than assigning a bunch of variables and doing an IF condition
+    -- This column list and the update statement below must be kept consistent between:
+    --   create_partition, check_subpart_sameconfig, create_partition_id, create_partition_time, dump_partitioned_table_definition, and table definition
+    FOR v_row IN
+        SELECT
+            sub_parent
+            , sub_control
+            , sub_time_encoder
+            , sub_time_decoder
+            , sub_partition_interval
+            , sub_partition_type
+            , sub_premake
+            , sub_automatic_maintenance
+            , sub_template_table
+            , sub_retention
+            , sub_retention_schema
+            , sub_retention_keep_index
+            , sub_retention_keep_table
+            , sub_epoch
+            , sub_constraint_cols
+            , sub_optimize_constraint
+            , sub_infinite_time_partitions
+            , sub_jobmon
+            , sub_inherit_privileges
+            , sub_constraint_valid
+            , sub_date_trunc_interval
+            , sub_ignore_default_data
+            , sub_default_table
+            , sub_maintenance_order
+            , sub_retention_keep_publication
+            , sub_control_not_null
+            , sub_detach_before_drop
+            , sub_maintenance_role
+        FROM @extschema@.part_config_sub
+        WHERE sub_parent = p_parent_table
+    LOOP
+        IF v_jobmon_schema IS NOT NULL THEN
+            v_step_id := add_step(v_job_id, format('Subpartitioning %s.%s', v_parent_schema, v_partition_name));
+        END IF;
+        v_sql := format('SELECT @extschema@.create_partition(
+                 p_parent_table := %L
+                , p_control := %L
+                , p_time_encoder := %L
+                , p_time_decoder := %L
+                , p_interval := %L
+                , p_type := %L
+                , p_default_table := %L
+                , p_constraint_cols := %L
+                , p_premake := %L
+                , p_automatic_maintenance := %L
+                , p_epoch := %L
+                , p_template_table := %L
+                , p_jobmon := %L
+                , p_start_partition := %L
+                , p_date_trunc_interval := %L
+                , p_control_not_null := %L )'
+            , v_parent_schema||'.'||v_partition_name
+            , v_row.sub_control
+            , v_row.sub_time_encoder
+            , v_row.sub_time_decoder
+            , v_row.sub_partition_interval
+            , v_row.sub_partition_type
+            , v_row.sub_default_table
+            , v_row.sub_constraint_cols
+            , v_row.sub_premake
+            , v_row.sub_automatic_maintenance
+            , v_row.sub_epoch
+            , v_row.sub_template_table
+            , v_row.sub_jobmon
+            , p_start_partition
+            , v_row.sub_date_trunc_interval
+            , v_row.sub_control_not_null);
+
+        RAISE DEBUG 'create_partition_time (create_partition loop): %', v_sql;
+        EXECUTE v_sql;
+
+        UPDATE @extschema@.part_config SET
+            retention_schema = v_row.sub_retention_schema
+            , retention_keep_table = v_row.sub_retention_keep_table
+            , optimize_constraint = v_row.sub_optimize_constraint
+            , infinite_time_partitions = v_row.sub_infinite_time_partitions
+            , inherit_privileges = v_row.sub_inherit_privileges
+            , constraint_valid = v_row.sub_constraint_valid
+            , ignore_default_data = v_row.sub_ignore_default_data
+            , maintenance_order = v_row.sub_maintenance_order
+            , retention_keep_publication = v_row.sub_retention_keep_publication
+            , detach_before_drop = v_row.sub_detach_before_drop
+            , maintenance_role = v_row.sub_maintenance_role
+        WHERE parent_table = v_parent_schema||'.'||v_partition_name;
+
+    END LOOP; -- end sub partitioning LOOP
+
+    -- NOTE: Replication identity not automatically inherited as of PG16 (revisit in future versions)
+    PERFORM @extschema@.inherit_replica_identity(v_parent_schema, v_parent_tablename, v_partition_name);
+
+    -- Manage additional constraints if set
+    PERFORM @extschema@.apply_constraints(p_parent_table, p_job_id := v_job_id);
+
+    v_partition_created := true;
+
+END LOOP;
+
+IF v_jobmon_schema IS NOT NULL THEN
+    IF v_partition_created = false THEN
+        v_step_id := add_step(v_job_id, format('No partitions created for partition set: %s. Attempted intervals: %s', p_parent_table, p_partition_times));
+        PERFORM update_step(v_step_id, 'OK', 'Done');
+    END IF;
+
+    IF v_step_overflow_id IS NOT NULL THEN
+        PERFORM fail_job(v_job_id);
+    ELSE
+        PERFORM close_job(v_job_id);
+    END IF;
+END IF;
+
+RETURN v_partition_created;
+
+EXCEPTION
+    WHEN OTHERS THEN
+        GET STACKED DIAGNOSTICS ex_message = MESSAGE_TEXT,
+                                ex_context = PG_EXCEPTION_CONTEXT,
+                                ex_detail = PG_EXCEPTION_DETAIL,
+                                ex_hint = PG_EXCEPTION_HINT;
+        IF v_jobmon_schema IS NOT NULL THEN
+            IF v_job_id IS NULL THEN
+                EXECUTE format('SELECT %I.add_job(%L)', v_jobmon_schema, format('PARTMAN CREATE TABLE: %s', p_parent_table)) INTO v_job_id;
+                EXECUTE format('SELECT %I.add_step(%s, ''EXCEPTION before job logging started'')', v_jobmon_schema, v_job_id, p_parent_table) INTO v_step_id;
+            ELSIF v_step_id IS NULL THEN
+                EXECUTE format('SELECT %I.add_step(%s, ''EXCEPTION before first step logged'')', v_jobmon_schema, v_job_id) INTO v_step_id;
+            END IF;
+            EXECUTE format('SELECT %I.update_step(%s, ''CRITICAL'', %L)', v_jobmon_schema, v_step_id, 'ERROR: '||coalesce(SQLERRM,'unknown'));
+            EXECUTE format('SELECT %I.fail_job(%s)', v_jobmon_schema, v_job_id);
+        END IF;
+        RAISE EXCEPTION '%
+CONTEXT: %
+DETAIL: %
+HINT: %', ex_message, ex_context, ex_detail, ex_hint;
+END
+$$;
+
+
+
+CREATE OR REPLACE FUNCTION @extschema@.create_partition_id(
+    p_parent_table text
+    , p_partition_ids bigint[]
+    , p_start_partition text DEFAULT NULL
+)
+    RETURNS boolean
+    LANGUAGE plpgsql
+    SET search_path = @extschema@, pg_catalog, pg_temp
+    AS $$
+DECLARE
+
+ex_context                      text;
+ex_detail                       text;
+ex_hint                         text;
+ex_message                      text;
+v_child_table_prefix            text;
+v_control                       text;
+v_control_type                  text;
+v_exists                        text;
+v_id                            bigint;
+v_inherit_privileges            boolean;
+v_job_id                        bigint;
+v_jobmon                        boolean;
+v_jobmon_schema                 text;
+v_new_search_path               text;
+v_old_search_path               text;
+v_parent_oid                    oid;
+v_parent_schema                 text;
+v_parent_tablename              text;
+v_parent_tablespace             name;
+v_partition_interval            bigint;
+v_partition_created             boolean := false;
+v_partition_name                text;
+v_partition_type                text;
+v_row                           record;
+v_sql                           text;
+v_step_id                       bigint;
+v_sub_control                   text;
+v_sub_partition_type            text;
+v_sub_id_max                    bigint;
+v_sub_id_min                    bigint;
+v_template_table                text;
+
+BEGIN
+/*
+ * Function to create id partitions
+ */
+
+SELECT control
+    , partition_interval::bigint -- this shared field also used in partition_time as interval
+    , partition_type
+    , jobmon
+    , template_table
+    , inherit_privileges
+    , child_table_prefix
+INTO v_control
+    , v_partition_interval
+    , v_partition_type
+    , v_jobmon
+    , v_template_table
+    , v_inherit_privileges
+    , v_child_table_prefix
+FROM @extschema@.part_config
+WHERE parent_table = p_parent_table;
+
+IF NOT FOUND THEN
+    RAISE EXCEPTION 'ERROR: no config found for %', p_parent_table;
+END IF;
+
+SELECT n.nspname
+    , c.relname
+    , c.oid
+    , t.spcname
+INTO v_parent_schema
+    , v_parent_tablename
+    , v_parent_oid
+    , v_parent_tablespace
+FROM pg_catalog.pg_class c
+JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
+LEFT OUTER JOIN pg_catalog.pg_tablespace t ON c.reltablespace = t.oid
+WHERE n.nspname = split_part(p_parent_table, '.', 1)::name
+AND c.relname = split_part(p_parent_table, '.', 2)::name;
+
+SELECT general_type INTO v_control_type FROM @extschema@.check_control_type(v_parent_schema, v_parent_tablename, v_control);
+IF v_control_type <> 'id' THEN
+    RAISE EXCEPTION 'ERROR: Given parent table is not set up for id/serial partitioning';
+END IF;
+
+IF v_jobmon THEN
+    SELECT nspname INTO v_jobmon_schema FROM pg_catalog.pg_namespace n, pg_catalog.pg_extension e WHERE e.extname = 'pg_jobmon'::name AND e.extnamespace = n.oid;
+    IF v_jobmon_schema IS NOT NULL THEN
+        SELECT current_setting('search_path') INTO v_old_search_path;
+        IF v_jobmon_schema IS NOT NULL THEN
+            v_new_search_path := format('%s,%s',v_jobmon_schema, v_old_search_path);
+            EXECUTE format('SET LOCAL search_path TO %s', v_new_search_path);
+        END IF;
+    END IF;
+END IF;
+
+-- Determine if this table is a child of a subpartition parent. If so, get limits of what child tables can be created based on parent suffix
+SELECT sub_min::bigint, sub_max::bigint INTO v_sub_id_min, v_sub_id_max FROM @extschema@.check_subpartition_limits(p_parent_table, 'id');
+
+IF v_jobmon_schema IS NOT NULL THEN
+    v_job_id := add_job(format('PARTMAN CREATE TABLE: %s', p_parent_table));
+END IF;
+
+FOREACH v_id IN ARRAY p_partition_ids LOOP
+-- Do not create the child table if it's outside the bounds of the top parent.
+    IF v_sub_id_min IS NOT NULL THEN
+        IF v_id < v_sub_id_min OR v_id >= v_sub_id_max THEN
+            CONTINUE;
+        END IF;
+    END IF;
+
+    v_partition_name := @extschema@.check_name_length(v_parent_tablename, v_id::text, TRUE, v_child_table_prefix);
+    -- If child table already exists, skip creation
+    -- Have to check pg_class because if subpartitioned, table will not be in pg_tables
+    SELECT c.relname INTO v_exists
+    FROM pg_catalog.pg_class c
+    JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
+    WHERE n.nspname = v_parent_schema::name AND c.relname = v_partition_name::name;
+    IF v_exists IS NOT NULL THEN
+        CONTINUE;
+    END IF;
+
+    IF v_jobmon_schema IS NOT NULL THEN
+        v_step_id := add_step(v_job_id, 'Creating new partition '||v_partition_name||' with interval from '||v_id||' to '||(v_id + v_partition_interval)-1);
+    END IF;
+
+    -- Same INCLUDING list is used in create_partition()
+    v_sql := format('CREATE TABLE %I.%I (LIKE %I.%I  INCLUDING COMMENTS INCLUDING COMPRESSION INCLUDING CONSTRAINTS INCLUDING DEFAULTS INCLUDING GENERATED INCLUDING STATISTICS INCLUDING STORAGE) '
+            , v_parent_schema
+            , v_partition_name
+            , v_parent_schema
+            , v_parent_tablename);
+
+    IF v_parent_tablespace IS NOT NULL THEN
+        v_sql := format('%s TABLESPACE %I ', v_sql, v_parent_tablespace);
+    END IF;
+
+    SELECT sub_partition_type, sub_control INTO v_sub_partition_type, v_sub_control
+    FROM @extschema@.part_config_sub
+    WHERE sub_parent = p_parent_table;
+    IF v_sub_partition_type = 'range' THEN
+        v_sql :=  format('%s PARTITION BY RANGE (%I) ', v_sql, v_sub_control);
+    ELSIF v_sub_partition_type = 'list' THEN
+        v_sql :=  format('%s PARTITION BY LIST (%I) ', v_sql, v_sub_control);
+    END IF;
+
+    RAISE DEBUG 'create_partition_id v_sql: %', v_sql;
+    EXECUTE v_sql;
+
+    PERFORM @extschema@.inherit_parent_properties(v_parent_schema, v_parent_tablename, v_partition_name);
+
+    IF v_template_table IS NOT NULL THEN
+        PERFORM @extschema@.inherit_template_properties(p_parent_table, v_parent_schema, v_partition_name);
+    END IF;
+
+    IF v_partition_type = 'range' THEN
+        EXECUTE format('ALTER TABLE %I.%I ATTACH PARTITION %I.%I FOR VALUES FROM (%L) TO (%L)'
+            , v_parent_schema
+            , v_parent_tablename
+            , v_parent_schema
+            , v_partition_name
+            , v_id
+            , v_id + v_partition_interval);
+    ELSIF v_partition_type = 'list' THEN
+        EXECUTE format('ALTER TABLE %I.%I ATTACH PARTITION %I.%I FOR VALUES IN (%L)'
+            , v_parent_schema
+            , v_parent_tablename
+            , v_parent_schema
+            , v_partition_name
+            , v_id);
+    ELSE
+        RAISE EXCEPTION 'create_partition_id: Unexpected partition type (%) encountered in part_config table for parent table %', v_partition_type, p_parent_table;
+    END IF;
+
+    -- NOTE: Privileges not automatically inherited. Only do so if config flag is set
+    IF v_inherit_privileges = TRUE THEN
+        PERFORM @extschema@.apply_privileges(v_parent_schema, v_parent_tablename, v_parent_schema, v_partition_name, v_job_id);
+    END IF;
+
+    IF v_jobmon_schema IS NOT NULL THEN
+        PERFORM update_step(v_step_id, 'OK', 'Done');
+    END IF;
+
+    -- Will only loop once and only if sub_partitioning is actually configured
+    -- This seemed easier than assigning a bunch of variables then doing an IF condition
+    -- This column list and the update statement below must be kept consistent between:
+    --   create_partition, check_subpart_sameconfig, create_partition_id, create_partition_time, dump_partitioned_table_definition, and table definition
+    FOR v_row IN
+        SELECT
+            sub_parent
+            , sub_control
+            , sub_time_encoder
+            , sub_time_decoder
+            , sub_partition_interval
+            , sub_partition_type
+            , sub_premake
+            , sub_automatic_maintenance
+            , sub_template_table
+            , sub_retention
+            , sub_retention_schema
+            , sub_retention_keep_index
+            , sub_retention_keep_table
+            , sub_epoch
+            , sub_constraint_cols
+            , sub_optimize_constraint
+            , sub_infinite_time_partitions
+            , sub_jobmon
+            , sub_inherit_privileges
+            , sub_constraint_valid
+            , sub_date_trunc_interval
+            , sub_ignore_default_data
+            , sub_default_table
+            , sub_maintenance_order
+            , sub_retention_keep_publication
+            , sub_control_not_null
+            , sub_detach_before_drop
+            , sub_maintenance_role
+        FROM @extschema@.part_config_sub
+        WHERE sub_parent = p_parent_table
+    LOOP
+        IF v_jobmon_schema IS NOT NULL THEN
+            v_step_id := add_step(v_job_id, 'Subpartitioning '||v_partition_name);
+        END IF;
+        v_sql := format('SELECT @extschema@.create_partition(
+                 p_parent_table := %L
+                , p_control := %L
+                , p_time_encoder := %L
+                , p_time_decoder := %L
+                , p_type := %L
+                , p_interval := %L
+                , p_default_table := %L
+                , p_constraint_cols := %L
+                , p_premake := %L
+                , p_automatic_maintenance := %L
+                , p_epoch := %L
+                , p_template_table := %L
+                , p_jobmon := %L
+                , p_start_partition := %L
+                , p_date_trunc_interval := %L
+                , p_control_not_null := %L )'
+            , v_parent_schema||'.'||v_partition_name
+            , v_row.sub_control
+            , v_row.sub_time_encoder
+            , v_row.sub_time_decoder
+            , v_row.sub_partition_type
+            , v_row.sub_partition_interval
+            , v_row.sub_default_table
+            , v_row.sub_constraint_cols
+            , v_row.sub_premake
+            , v_row.sub_automatic_maintenance
+            , v_row.sub_epoch
+            , v_row.sub_template_table
+            , v_row.sub_jobmon
+            , p_start_partition
+            , v_row.sub_date_trunc_interval
+            , v_row.sub_control_not_null);
+        RAISE DEBUG 'create_partition_id (create_partition loop): %', v_sql;
+        EXECUTE v_sql;
+
+        UPDATE @extschema@.part_config SET
+            retention_schema = v_row.sub_retention_schema
+            , retention_keep_table = v_row.sub_retention_keep_table
+            , optimize_constraint = v_row.sub_optimize_constraint
+            , infinite_time_partitions = v_row.sub_infinite_time_partitions
+            , inherit_privileges = v_row.sub_inherit_privileges
+            , constraint_valid = v_row.sub_constraint_valid
+            , ignore_default_data = v_row.sub_ignore_default_data
+            , maintenance_order = v_row.sub_maintenance_order
+            , retention_keep_publication = v_row.sub_retention_keep_publication
+            , detach_before_drop = v_row.sub_detach_before_drop
+            , maintenance_role = v_row.sub_maintenance_role
+        WHERE parent_table = v_parent_schema||'.'||v_partition_name;
+
+        IF v_jobmon_schema IS NOT NULL THEN
+            PERFORM update_step(v_step_id, 'OK', 'Done');
+        END IF;
+
+    END LOOP; -- end sub partitioning LOOP
+
+    -- NOTE: Replication identity not automatically inherited as of PG16 (revisit in future versions)
+    PERFORM @extschema@.inherit_replica_identity(v_parent_schema, v_parent_tablename, v_partition_name);
+
+    -- Manage additional constraints if set
+    PERFORM @extschema@.apply_constraints(p_parent_table, p_job_id := v_job_id);
+    v_partition_created := true;
+
+END LOOP;
+
+IF v_jobmon_schema IS NOT NULL THEN
+    IF v_partition_created = false THEN
+        v_step_id := add_step(v_job_id, format('No partitions created for partition set: %s', p_parent_table));
+        PERFORM update_step(v_step_id, 'OK', 'Done');
+    END IF;
+
+    PERFORM close_job(v_job_id);
+END IF;
+
+RETURN v_partition_created;
+
+EXCEPTION
+    WHEN OTHERS THEN
+        GET STACKED DIAGNOSTICS ex_message = MESSAGE_TEXT,
+                                ex_context = PG_EXCEPTION_CONTEXT,
+                                ex_detail = PG_EXCEPTION_DETAIL,
+                                ex_hint = PG_EXCEPTION_HINT;
+        IF v_jobmon_schema IS NOT NULL THEN
+            IF v_job_id IS NULL THEN
+                EXECUTE format('SELECT %I.add_job(%L)', v_jobmon_schema, format('PARTMAN CREATE TABLE: %s', p_parent_table)) INTO v_job_id;
+                EXECUTE format('SELECT %I.add_step(%s, ''EXCEPTION before job logging started'')', v_jobmon_schema, v_job_id, p_parent_table) INTO v_step_id;
+            ELSIF v_step_id IS NULL THEN
+                EXECUTE format('SELECT %I.add_step(%s, ''EXCEPTION before first step logged'')', v_jobmon_schema, v_job_id) INTO v_step_id;
+            END IF;
+            EXECUTE format('SELECT %I.update_step(%s, ''CRITICAL'', %L)', v_jobmon_schema, v_step_id, 'ERROR: '||coalesce(SQLERRM,'unknown'));
+            EXECUTE format('SELECT %I.fail_job(%s)', v_jobmon_schema, v_job_id);
+        END IF;
+        RAISE EXCEPTION '%
+CONTEXT: %
+DETAIL: %
+HINT: %', ex_message, ex_context, ex_detail, ex_hint;
+END
+$$;
+
+
+
+CREATE OR REPLACE FUNCTION @extschema@.show_partition_name(
+    p_parent_table text, p_value text
+    , OUT partition_schema text
+    , OUT partition_table text
+    , OUT suffix_timestamp timestamptz
+    , OUT suffix_id bigint
+    , OUT table_exists boolean
+)
+    RETURNS record
+    LANGUAGE plpgsql STABLE
+    SET search_path = @extschema@, pg_catalog, pg_temp
+    AS $$
+DECLARE
+
+v_child_end_time                timestamptz;
+v_child_exists                  text;
+v_child_larger                  boolean := false;
+v_child_smaller                 boolean := false;
+v_child_start_time              timestamptz;
+v_child_table_prefix            text;
+v_control                       text;
+v_time_encoder                  text;
+v_control_type                  text;
+v_datetime_string               text;
+v_epoch                         text;
+v_given_timestamp               timestamptz;
+v_parent_schemaname                 text;
+v_parent_tablename              text;
+v_partition_interval            text;
+v_row                           record;
+v_type                          text;
+
+BEGIN
+/*
+ * Given a parent table and partition value, return the name of the child partition it would go in.
+ * If using epoch time partitioning, give the text representation of the timestamp NOT the epoch integer value (use to_timestamp() to convert epoch values).
+ * Also returns just the suffix value and true if the child table exists or false if it does not
+ */
+
+SELECT partition_type
+    , control
+    , time_encoder
+    , partition_interval
+    , datetime_string
+    , epoch
+    , child_table_prefix
+INTO v_type
+    , v_control
+    , v_time_encoder
+    , v_partition_interval
+    , v_datetime_string
+    , v_epoch
+    , v_child_table_prefix
+FROM @extschema@.part_config
+WHERE parent_table = p_parent_table;
+
+IF v_type IS NULL THEN
+    RAISE EXCEPTION 'Parent table given is not managed by pg_partman (%)', p_parent_table;
+END IF;
+
+SELECT n.nspname, c.relname INTO v_parent_schemaname, v_parent_tablename
+FROM pg_catalog.pg_class c
+JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
+WHERE n.nspname = split_part(p_parent_table, '.', 1)::name
+AND c.relname = split_part(p_parent_table, '.', 2)::name;
+IF v_parent_tablename IS NULL THEN
+    RAISE EXCEPTION 'Parent table given does not exist (%)', p_parent_table;
+END IF;
+
+partition_schema := v_parent_schemaname;
+
+SELECT general_type INTO v_control_type FROM @extschema@.check_control_type(v_parent_schemaname, v_parent_tablename, v_control);
+
+IF (v_control_type IN ('time', 'text', 'uuid') OR (v_control_type = 'id' AND v_epoch <> 'none')) THEN
+
+    v_given_timestamp := p_value::timestamptz;
+    RAISE DEBUG 'show_partition_name: v_given_timestamp: %, v_child_start_time: %, v_child_end_time: % ', v_given_timestamp, v_child_start_time, v_child_end_time;
+
+    FOR v_row IN
+        SELECT partition_schemaname ||'.'|| partition_tablename AS child_table FROM @extschema@.show_partitions(p_parent_table, 'DESC')
+    LOOP
+    RAISE DEBUG 'show_partition_name: v_row.child_table: %', v_row.child_table;
+        SELECT child_start_time INTO v_child_start_time
+            FROM @extschema@.show_partition_info(v_row.child_table, v_partition_interval, p_parent_table);
+        -- Don't use child_end_time from above function to avoid edge cases around user supplied timestamps
+        v_child_end_time := v_child_start_time + v_partition_interval::interval;
+    RAISE DEBUG 'show_partition_name: v_given_timestamp: %, v_child_start_time: %, v_child_end_time: % ', v_given_timestamp, v_child_start_time, v_child_end_time;
+
+        IF v_given_timestamp >= v_child_end_time THEN
+            -- given value is higher than any existing child table. handled below.
+            v_child_larger := true;
+            EXIT;
+        END IF;
+        IF v_given_timestamp >= v_child_start_time THEN
+            -- found target child table
+            v_child_smaller := false;
+            suffix_timestamp := v_child_start_time;
+            EXIT;
+        END IF;
+        -- Should only get here if no matching child table was found. handled below.
+        v_child_smaller := true;
+    END LOOP;
+
+    IF v_child_start_time IS NULL OR v_child_end_time IS NULL THEN
+        -- This should never happen since there should never be a partition set without children.
+        -- Handling just in case so issues can be reported with context
+        RAISE EXCEPTION 'Unexpected code path encountered in show_partition_name(). Please report this issue to author with relevant partition config info.';
+    END IF;
+
+    IF v_child_larger THEN
+        LOOP
+            -- keep adding interval until found
+            v_child_start_time := v_child_start_time + v_partition_interval::interval;
+            v_child_end_time := v_child_end_time + v_partition_interval::interval;
+            IF v_given_timestamp >= v_child_start_time AND v_given_timestamp < v_child_end_time THEN
+                suffix_timestamp := v_child_start_time;
+                EXIT;
+            END IF;
+        END LOOP;
+    ELSIF v_child_smaller THEN
+        LOOP
+            -- keep subtracting interval until found
+            v_child_start_time := v_child_start_time - v_partition_interval::interval;
+            v_child_end_time := v_child_end_time - v_partition_interval::interval;
+            IF v_given_timestamp >= v_child_start_time AND v_given_timestamp < v_child_end_time THEN
+                suffix_timestamp := v_child_start_time;
+                EXIT;
+            END IF;
+        END LOOP;
+    END IF;
+
+    partition_table := @extschema@.check_name_length(v_parent_tablename, to_char(suffix_timestamp, v_datetime_string), TRUE, v_child_table_prefix);
+
+ELSIF v_control_type = 'id' THEN
+    suffix_id := (p_value::bigint - (p_value::bigint % v_partition_interval::bigint));
+    partition_table := @extschema@.check_name_length(v_parent_tablename, suffix_id::text, TRUE, v_child_table_prefix);
+
+ELSE
+    RAISE EXCEPTION 'Unexpected code path encountered in show_partition_name(). No valid control type found. Please report this issue to author with relevant partition config info.';
+END IF;
+
+SELECT tablename INTO v_child_exists
+FROM pg_catalog.pg_tables
+WHERE schemaname = partition_schema::name
+AND tablename = partition_table::name;
+
+IF v_child_exists IS NOT NULL THEN
+    table_exists := true;
+ELSE
+    table_exists := false;
+END IF;
+
+RETURN;
+
+END
+$$;
+
+
+CREATE OR REPLACE FUNCTION @extschema@.partition_data_time(
+    p_parent_table text
+    , p_batch_count int DEFAULT 1
+    , p_batch_interval interval DEFAULT NULL
+    , p_lock_wait numeric DEFAULT 0
+    , p_order text DEFAULT 'ASC'
+    , p_analyze boolean DEFAULT true
+    , p_source_table text DEFAULT NULL
+    , p_ignored_columns text[] DEFAULT NULL
+    , p_override_system_value boolean DEFAULT false
+    , p_ignore_infinity boolean DEFAULT false
+)
+    RETURNS bigint
+    LANGUAGE plpgsql
+    SET search_path = @extschema@, pg_catalog, pg_temp
+    AS $$
+DECLARE
+
+v_analyze                   boolean := FALSE;
+v_async_rowcount            int;
+v_child_table_prefix        text;
+v_column_list_filtered      text;
+v_column_list_full          text;
+v_control                   text;
+v_control_exact_type        text;
+v_control_type              text;
+v_datetime_string           text;
+v_current_partition_name    text;
+v_decoded_col               text;
+v_default_exists            boolean;
+v_default_schemaname        text;
+v_default_tablename         text;
+v_epoch                     text;
+v_infinity_sql              text;
+v_last_partition            text;
+v_lock_iter                 int := 1;
+v_lock_obtained             boolean := FALSE;
+v_max_partition_timestamp   timestamptz;
+v_min_partition_timestamp   timestamptz;
+v_override_statement        text;
+v_parent_schemaname         text;
+v_parent_tablename          text;
+v_partition_expression      text;
+v_partition_interval        interval;
+v_partition_suffix          text;
+v_partition_timestamp       timestamptz[];
+v_source_schemaname         text;
+v_source_tablename          text;
+v_rowcount                  bigint;
+v_sql                       text;
+v_start_control             timestamptz;
+v_temp_storage_table        text;
+v_time_decoder              text;
+v_time_decoder_safe         text;
+v_time_encoder              text;
+v_total_rows                bigint := 0;
+
+BEGIN
+/*
+ * Populate the child table(s) of a time-based partition set with data from the default or a source table
+ */
+
+SELECT partition_interval::interval
+    , control
+    , time_encoder
+    , time_decoder
+    , datetime_string
+    , epoch
+    , child_table_prefix
+INTO v_partition_interval
+    , v_control
+    , v_time_encoder
+    , v_time_decoder
+    , v_datetime_string
+    , v_epoch
+    , v_child_table_prefix
+FROM @extschema@.part_config
+WHERE parent_table = p_parent_table;
+IF NOT FOUND THEN
+    RAISE EXCEPTION 'ERROR: No entry in part_config found for given table:  %', p_parent_table;
+END IF;
+
+IF p_ignore_infinity THEN
+    IF p_source_table IS NOT NULL THEN
+        RAISE EXCEPTION 'The ignore infinity parameter is only for usage when moving data out of the default. Found that p_source_table was set: %', p_source_table;
+    END IF;
+    IF v_time_encoder IS NOT NULL OR v_time_decoder IS NOT NULL THEN
+        RAISE EXCEPTION 'p_ignore_infinity cannot be set when using encoded time values. part_config.time_encoder has value: %', v_time_encoder;
+    END IF;
+END IF;
+
+SELECT schemaname, tablename INTO v_parent_schemaname, v_parent_tablename
+FROM pg_catalog.pg_tables
+WHERE schemaname = split_part(p_parent_table, '.', 1)::name
+AND tablename = split_part(p_parent_table, '.', 2)::name;
+
+SELECT general_type, exact_type INTO v_control_type, v_control_exact_type FROM @extschema@.check_control_type(v_parent_schemaname, v_parent_tablename, v_control);
+IF v_control_type <> 'time' THEN
+    IF (v_control_type = 'id' AND v_epoch = 'none') OR v_control_type NOT IN ('text', 'id', 'uuid') OR (v_control_type IN ('text', 'uuid') AND v_time_encoder IS NULL) THEN
+        RAISE EXCEPTION 'Cannot run on partition set without time based control column, an epoch flag set with an id column or time_encoder set with text column. Found control: %, epoch: %, time_encoder: %s', v_control_type, v_epoch, v_time_encoder;
+    END IF;
+END IF;
+
+SELECT n.nspname::text, c.relname::text
+INTO v_default_schemaname, v_default_tablename
+FROM pg_catalog.pg_inherits h
+JOIN pg_catalog.pg_class c ON c.oid = h.inhrelid
+JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
+WHERE h.inhparent = format('%I.%I', v_parent_schemaname, v_parent_tablename)::regclass
+AND pg_get_expr(relpartbound, c.oid) = 'DEFAULT';
+
+IF p_source_table IS NOT NULL THEN
+    -- Set source table to user given source table instead of default table
+    v_source_schemaname := NULL;
+    v_source_tablename := NULL;
+
+    SELECT schemaname, tablename INTO v_source_schemaname, v_source_tablename
+    FROM pg_catalog.pg_tables
+    WHERE schemaname = split_part(p_source_table, '.', 1)::name
+    AND tablename = split_part(p_source_table, '.', 2)::name;
+
+    IF v_default_tablename IS NOT NULL THEN
+        -- Cannot set source parameter to default. Otherwise things get put into a weird loop since data is getting put back into where it was just pulled out
+        IF v_default_schemaname = v_source_schemaname AND v_default_tablename = v_source_tablename THEN
+            RAISE EXCEPTION 'Cannot set p_source_table to the same value as the default table for this partition set. If you are moving data out of the default, please leave p_source_table unset and data will be moved out of the default table automatically.';
+        END IF;
+    END IF;
+
+    IF v_source_tablename IS NULL THEN
+        RAISE EXCEPTION 'Given source table does not exist in system catalogs: %', p_source_table;
+    END IF;
+
+
+ELSE
+
+    IF p_batch_interval IS NOT NULL AND p_batch_interval != v_partition_interval THEN
+        -- This is true because all data for a given child table must be moved out of the default partition before the child table can be created.
+        -- So cannot create the child table when only some of the data has been moved out of the default partition.
+        RAISE EXCEPTION 'If any interval smaller than the partition interval must be used for moving data out of the default, please use the partition_data_async() procedure.';
+    END IF;
+
+    -- Set source table to default table if p_source_table is not set, and it exists
+    -- Otherwise just return with a NOTICE that no data source exists
+
+    IF v_default_tablename IS NOT NULL THEN
+        v_source_schemaname := v_default_schemaname;
+        v_source_tablename := v_default_tablename;
+
+        v_default_exists := true;
+
+            v_temp_storage_table := format('%I', 'partman_temp_data_storage');
+            EXECUTE format ('CREATE TEMP TABLE IF NOT EXISTS %s (LIKE %I.%I INCLUDING INDEXES) ON COMMIT DROP', v_temp_storage_table, v_source_schemaname, v_source_tablename);
+
+    ELSE
+        RAISE NOTICE 'No default table found when partition_data_time() was called';
+        RETURN v_total_rows;
+    END IF;
+END IF;
+
+IF p_batch_interval IS NULL OR p_batch_interval > v_partition_interval THEN
+    p_batch_interval := v_partition_interval;
+END IF;
+
+SELECT partition_tablename INTO v_last_partition FROM @extschema@.show_partitions(p_parent_table, 'DESC') LIMIT 1;
+
+v_partition_expression := CASE
+    WHEN v_epoch = 'seconds' THEN format('to_timestamp(%I)', v_control)
+    WHEN v_epoch = 'milliseconds' THEN format('to_timestamp((%I/1000)::float)', v_control)
+    WHEN v_epoch = 'microseconds' THEN format('to_timestamp((%I/1000000)::float)', v_control)
+    WHEN v_epoch = 'nanoseconds' THEN format('to_timestamp((%I/1000000000)::float)', v_control)
+    ELSE format('%I', v_control)
+END;
+
+-- Generate filtered column list to use in SELECT/INSERT statements below. Allows for exclusion of GENERATED (or any other desired) columns.
+SELECT string_agg(quote_ident(attname), ',')
+INTO v_column_list_filtered
+FROM pg_catalog.pg_attribute a
+JOIN pg_catalog.pg_class c ON a.attrelid = c.oid
+JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
+WHERE n.nspname = v_source_schemaname
+AND c.relname = v_source_tablename
+AND a.attnum > 0
+AND a.attisdropped = false
+AND attname <> ALL(COALESCE(p_ignored_columns, ARRAY[]::text[]));
+
+-- Generate full column list to use in SELECT/INSERT statements below when temp table is in use
+SELECT string_agg(quote_ident(attname), ',')
+INTO v_column_list_full
+FROM pg_catalog.pg_attribute a
+JOIN pg_catalog.pg_class c ON a.attrelid = c.oid
+JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
+WHERE n.nspname = v_source_schemaname
+AND c.relname = v_source_tablename
+AND a.attnum > 0
+AND a.attisdropped = false;
+
+IF p_ignore_infinity AND v_time_decoder IS NULL THEN
+    v_infinity_sql := format(' WHERE %I NOT IN (''-infinity'', ''infinity'')', v_control);
+ELSIF p_ignore_infinity AND v_time_decoder IS NOT NULL THEN
+    RAISE EXCEPTION 'When using a decoder for partition values, infinity cannot be ignored and is generally not supported as a value.';
+ELSE
+    v_infinity_sql := '';
+END IF;
+
+IF v_time_decoder IS NOT NULL THEN
+    v_time_decoder_safe := partman_safe_obj_name(v_time_decoder);
+END IF;
+
+FOR i IN 1..p_batch_count LOOP
+
+    IF v_time_decoder IS NULL THEN
+        IF p_order = 'ASC' THEN
+            EXECUTE format('SELECT min(%s) FROM ONLY %I.%I %s', v_partition_expression, v_source_schemaname, v_source_tablename, v_infinity_sql) INTO v_start_control;
+        ELSIF p_order = 'DESC' THEN
+            EXECUTE format('SELECT max(%s) FROM ONLY %I.%I %s', v_partition_expression, v_source_schemaname, v_source_tablename, v_infinity_sql) INTO v_start_control;
+        ELSE
+            RAISE EXCEPTION 'Invalid value for p_order. Must be ASC or DESC';
+        END IF;
+
+    ELSE
+	-- Currently time decoder function must take a text parameter. See if this can be more flexible in the future
+    -- infinity value not supported in uuid columns, so shouldn't have to worry about it. Exception catches it above if user tries to ignore infinity.
+
+
+        IF p_order = 'ASC' THEN
+            EXECUTE format('SELECT min(%s(%s::text)) FROM ONLY %I.%I', v_time_decoder_safe, v_partition_expression, v_source_schemaname, v_source_tablename) INTO v_start_control;
+        ELSIF p_order = 'DESC' THEN
+            EXECUTE format('SELECT max(%s(%s::text)) FROM ONLY %I.%I', v_time_decoder_safe, v_partition_expression, v_source_schemaname, v_source_tablename) INTO v_start_control;
+        ELSE
+            RAISE EXCEPTION 'Invalid value for p_order. Must be ASC or DESC';
+        END IF;
+    END IF;
+
+    IF v_start_control IS NULL THEN
+       EXIT;
+    END IF;
+
+    SELECT child_start_time INTO v_min_partition_timestamp FROM @extschema@.show_partition_info(v_parent_schemaname||'.'||v_last_partition
+        , v_partition_interval::text
+        , p_parent_table);
+    v_max_partition_timestamp := v_min_partition_timestamp + v_partition_interval;
+    LOOP
+        IF v_start_control >= v_min_partition_timestamp AND v_start_control < v_max_partition_timestamp THEN
+            EXIT;
+        ELSE
+            BEGIN
+                IF v_start_control >= v_max_partition_timestamp THEN
+                    -- Keep going forward in time, checking if child partition time interval encompasses the current v_start_control value
+                    v_min_partition_timestamp := v_max_partition_timestamp;
+                    v_max_partition_timestamp := v_max_partition_timestamp + v_partition_interval;
+
+                ELSE
+                    -- Keep going backwards in time, checking if child partition time interval encompasses the current v_start_control value
+                    v_max_partition_timestamp := v_min_partition_timestamp;
+                    v_min_partition_timestamp := v_min_partition_timestamp - v_partition_interval;
+                END IF;
+            EXCEPTION WHEN datetime_field_overflow THEN
+                RAISE EXCEPTION 'Attempted partition time interval is outside PostgreSQL''s supported time range.
+                    Unable to create partition with interval before timestamp % ', v_min_partition_timestamp;
+            END;
+        END IF;
+    END LOOP;
+
+    v_partition_timestamp := ARRAY[v_min_partition_timestamp];
+    IF p_order = 'ASC' THEN
+        -- Ensure batch interval given as parameter doesn't cause maximum to overflow the current partition maximum
+        IF (v_start_control + p_batch_interval) >= (v_min_partition_timestamp + v_partition_interval) THEN
+            v_max_partition_timestamp := v_min_partition_timestamp + v_partition_interval;
+        ELSE
+            v_max_partition_timestamp := v_start_control + p_batch_interval;
+        END IF;
+    ELSIF p_order = 'DESC' THEN
+        -- Must be greater than max value still in parent table since query below grabs < max
+        v_max_partition_timestamp := v_min_partition_timestamp + v_partition_interval;
+        -- Ensure batch interval given as parameter doesn't cause minimum to underflow current partition minimum
+        IF (v_start_control - p_batch_interval) >= v_min_partition_timestamp THEN
+            v_min_partition_timestamp := v_start_control - p_batch_interval;
+        END IF;
+    ELSE
+        RAISE EXCEPTION 'Invalid value for p_order. Must be ASC or DESC';
+    END IF;
+
+-- do some locking with timeout, if required
+    IF p_lock_wait > 0  THEN
+        v_lock_iter := 0;
+        WHILE v_lock_iter <= 5 LOOP
+            v_lock_iter := v_lock_iter + 1;
+            BEGIN
+                v_sql := format('SELECT * FROM ONLY %I.%I WHERE %s >= %L AND %4$s < %6$L FOR UPDATE NOWAIT'
+                    , v_source_schemaname
+                    , v_source_tablename
+                    , v_partition_expression
+                    , v_min_partition_timestamp
+                    , v_max_partition_timestamp);
+                EXECUTE v_sql;
+                v_lock_obtained := TRUE;
+            EXCEPTION
+                WHEN lock_not_available THEN
+                    PERFORM pg_sleep( p_lock_wait / 5.0 );
+                    CONTINUE;
+            END;
+            EXIT WHEN v_lock_obtained;
+        END LOOP;
+        IF NOT v_lock_obtained THEN
+           RETURN -1;
+        END IF;
+    END IF;
+
+    -- This suffix generation code is in create_partition_time() as well
+    v_partition_suffix := to_char(v_min_partition_timestamp, v_datetime_string);
+    v_current_partition_name := @extschema@.check_name_length(v_parent_tablename, v_partition_suffix, TRUE, v_child_table_prefix);
+
+    IF p_override_system_value THEN
+        v_override_statement = ' OVERRIDING SYSTEM VALUE ';
+    ELSE
+        v_override_statement = ' ';
+    END IF;
+
+    -- Create a variable to use in all scenarios below for handling encoded columns
+
+    IF v_time_decoder IS NULL THEN
+        IF v_control_exact_type = 'timestamp' THEN
+            -- Conversion to text of timestamp without timezone cannot be directly compared to timestamptz
+            -- that is returned by other functions and used below (See Github Issue #838)
+            v_decoded_col := format('%s::timestamptz::text', v_partition_expression);
+        ELSE
+            v_decoded_col := format('%s::text', v_partition_expression);
+        END IF;
+    ELSE
+        v_decoded_col := format('%s(%s::text)', v_time_decoder_safe, v_partition_expression);
+    END IF;
+
+    IF v_default_exists THEN
+        -- Child tables cannot be created if data that belongs to it exists in the default
+        -- Have to move data out to temporary location, create child table, then move it back
+
+        -- Temp table created above to avoid excessive temp creation in loop
+        -- Must use full column list here since the temp table cannot have generated/identity values for defaults.
+        --      This allows for all scenarios where some people may want newly generated values and others may not.
+        --      Those that want them are handled by the filtered column list when moving to the real table
+
+        -- Infinity only needs to be of concern when being removed from the default
+
+            v_sql := format('DELETE FROM %1$I.%2$I WHERE %3$s >= %4$L AND %3$s < %5$L RETURNING *'
+                , v_source_schemaname
+                , v_source_tablename
+                , v_decoded_col
+                , v_min_partition_timestamp
+                , v_max_partition_timestamp);
+            v_sql := format('WITH partition_data AS (%s) INSERT INTO %2$s (%3$s) SELECT %3$s FROM partition_data'
+                , v_sql
+                , v_temp_storage_table
+                , v_column_list_full);
+
+            EXECUTE v_sql;
+
+            -- Set analyze to true if a table is created
+        v_analyze := @extschema@.create_partition_time(p_parent_table, v_partition_timestamp);
+
+        EXECUTE format('WITH partition_data AS (
+                DELETE FROM %s RETURNING *)
+            INSERT INTO %I.%I (%4$s) %5$s SELECT %4$s FROM partition_data'
+            , v_temp_storage_table
+            , v_parent_schemaname
+            , v_current_partition_name
+            , v_column_list_filtered
+            , v_override_statement);
+
+    ELSE
+
+        -- Set analyze to true if a table is created
+        v_analyze := @extschema@.create_partition_time(p_parent_table, v_partition_timestamp);
+
+            v_sql := format('WITH partition_data AS (
+                                DELETE FROM ONLY %I.%I WHERE %3$s >= %L AND %3$s < %5$L RETURNING *)
+                             INSERT INTO %6$I.%7$I (%8$s) %9$s SELECT %8$s FROM partition_data'
+                                , v_source_schemaname
+                                , v_source_tablename
+                                , v_decoded_col
+                                , v_min_partition_timestamp
+                                , v_max_partition_timestamp
+                                , v_parent_schemaname
+                                , v_current_partition_name
+                                , v_column_list_filtered
+                                , v_override_statement);
+            EXECUTE v_sql;
+
+    END IF;
+
+    GET DIAGNOSTICS v_rowcount = ROW_COUNT;
+    v_total_rows := v_total_rows + v_rowcount;
+    IF v_rowcount = 0 THEN
+        EXIT;
+    END IF;
+
+END LOOP;
+
+-- v_analyze is a local check if a new table is made.
+-- p_analyze is a parameter to say whether to run the analyze at all. Used by create_partition() to avoid long exclusive lock or run_maintenance() to avoid long creation runs.
+IF v_analyze AND p_analyze THEN
+    RAISE DEBUG 'partiton_data_time: Begin analyze of %.%', v_parent_schemaname, v_parent_tablename;
+    EXECUTE format('ANALYZE %I.%I', v_parent_schemaname, v_parent_tablename);
+    RAISE DEBUG 'partiton_data_time: End analyze of %.%', v_parent_schemaname, v_parent_tablename;
+END IF;
+
+RETURN v_total_rows;
+
+END
+$$;
+
+
+
+CREATE OR REPLACE FUNCTION @extschema@.partition_data_id(
+    p_parent_table text
+    , p_batch_count int DEFAULT 1
+    , p_batch_interval bigint DEFAULT NULL
+    , p_lock_wait numeric DEFAULT 0
+    , p_order text DEFAULT 'ASC'
+    , p_analyze boolean DEFAULT true
+    , p_source_table text DEFAULT NULL
+    , p_ignored_columns text[] DEFAULT NULL
+    , p_override_system_value boolean DEFAULT false
+)
+    RETURNS bigint
+    LANGUAGE plpgsql
+    SET search_path = @extschema@, pg_catalog, pg_temp
+    AS $$
+DECLARE
+
+v_analyze                   boolean := FALSE;
+v_child_table_prefix        text;
+v_column_list_filtered      text;
+v_column_list_full          text;
+v_control                   text;
+v_control_type              text;
+v_current_partition_name    text;
+v_default_exists            boolean;
+v_default_schemaname        text;
+v_default_tablename         text;
+v_epoch                     text;
+v_lock_iter                 int := 1;
+v_lock_obtained             boolean := FALSE;
+v_max_partition_id          bigint;
+v_min_partition_id          bigint;
+v_override_statement        text;
+v_parent_schemaname         text;
+v_parent_tablename          text;
+v_partition_interval        bigint;
+v_partition_id              bigint[];
+v_rowcount                  bigint;
+v_source_schemaname         text;
+v_source_tablename          text;
+v_sql                       text;
+v_start_control             bigint;
+v_total_rows                bigint := 0;
+
+BEGIN
+    /*
+     * Populate the child table(s) of an id-based partition set with data from the default or other given source
+     */
+
+    SELECT partition_interval::bigint
+    , control
+    , epoch
+    , child_table_prefix
+    INTO v_partition_interval
+    , v_control
+    , v_epoch
+    , v_child_table_prefix
+    FROM @extschema@.part_config
+    WHERE parent_table = p_parent_table;
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'ERROR: No entry in part_config found for given table:  %', p_parent_table;
+    END IF;
+
+SELECT schemaname, tablename INTO v_parent_schemaname, v_parent_tablename
+FROM pg_catalog.pg_tables
+WHERE schemaname = split_part(p_parent_table, '.', 1)::name
+AND tablename = split_part(p_parent_table, '.', 2)::name;
+
+SELECT general_type INTO v_control_type FROM @extschema@.check_control_type(v_parent_schemaname, v_parent_tablename, v_control);
+
+IF v_control_type <> 'id' OR (v_control_type = 'id' AND v_epoch <> 'none') THEN
+    RAISE EXCEPTION 'Control column for given partition set is not id/serial based or epoch flag is set for time-based partitioning.';
+END IF;
+
+SELECT n.nspname::text, c.relname::text
+INTO v_default_schemaname, v_default_tablename
+FROM pg_catalog.pg_inherits h
+JOIN pg_catalog.pg_class c ON c.oid = h.inhrelid
+JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
+WHERE h.inhparent = format('%I.%I', v_parent_schemaname, v_parent_tablename)::regclass
+AND pg_get_expr(relpartbound, c.oid) = 'DEFAULT';
+
+IF p_source_table IS NOT NULL THEN
+
+    SELECT schemaname, tablename INTO v_source_schemaname, v_source_tablename
+    FROM pg_catalog.pg_tables
+    WHERE schemaname = split_part(p_source_table, '.', 1)::name
+    AND tablename = split_part(p_source_table, '.', 2)::name;
+
+    IF v_source_tablename IS NULL THEN
+        RAISE EXCEPTION 'Given source table does not exist in system catalogs: %', p_source_table;
+    END IF;
+
+ELSE
+
+    IF p_batch_interval IS NOT NULL AND p_batch_interval != v_partition_interval THEN
+        -- This is true because all data for a given child table must be moved out of the default partition before the child table can be created.
+        -- So cannot create the child table when only some of the data has been moved out of the default partition.
+        RAISE EXCEPTION 'If any interval smaller than the partition interval must be used for moving data out of the default, please use the partition_data_async() procedure.';
+    END IF;
+
+    -- Set source table to default table if p_source_table is not set, and it exists
+    -- Otherwise just return with a NOTICE that no data source exists
+
+    IF v_default_tablename IS NOT NULL THEN
+        v_source_schemaname := v_default_schemaname;
+        v_source_tablename := v_default_tablename;
+
+        v_default_exists := true;
+        EXECUTE format ('CREATE TEMP TABLE IF NOT EXISTS partman_temp_data_storage (LIKE %I.%I INCLUDING DEFAULTS INCLUDING INDEXES) ON COMMIT DROP', v_source_schemaname, v_source_tablename);
+    ELSE
+        RAISE NOTICE 'No default table found when partition_data_id() was called';
+        RETURN v_total_rows;
+    END IF;
+
+END IF;
+
+IF p_batch_interval IS NULL OR p_batch_interval > v_partition_interval THEN
+    p_batch_interval := v_partition_interval;
+END IF;
+
+-- Generate filtered column list to use in SELECT/INSERT statements below. Allows for exclusion of GENERATED (or any other desired) columns.
+SELECT string_agg(quote_ident(attname), ',')
+INTO v_column_list_filtered
+FROM pg_catalog.pg_attribute a
+JOIN pg_catalog.pg_class c ON a.attrelid = c.oid
+JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
+WHERE n.nspname = v_source_schemaname
+AND c.relname = v_source_tablename
+AND a.attnum > 0
+AND a.attisdropped = false
+AND attname <> ALL(COALESCE(p_ignored_columns, ARRAY[]::text[]));
+
+-- Generate full column list to use in SELECT/INSERT statements below when temp table is in use
+SELECT string_agg(quote_ident(attname), ',')
+INTO v_column_list_full
+FROM pg_catalog.pg_attribute a
+JOIN pg_catalog.pg_class c ON a.attrelid = c.oid
+JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
+WHERE n.nspname = v_source_schemaname
+AND c.relname = v_source_tablename
+AND a.attnum > 0
+AND a.attisdropped = false;
+
+FOR i IN 1..p_batch_count LOOP
+
+    IF p_order = 'ASC' THEN
+        EXECUTE format('SELECT min(%I) FROM ONLY %I.%I', v_control, v_source_schemaname, v_source_tablename) INTO v_start_control;
+        IF v_start_control IS NULL THEN
+            EXIT;
+        END IF;
+        v_min_partition_id := v_start_control - (v_start_control % v_partition_interval);
+        v_partition_id := ARRAY[v_min_partition_id];
+        -- Check if custom batch interval overflows current partition maximum
+        IF (v_start_control + p_batch_interval) >= (v_min_partition_id + v_partition_interval) THEN
+            v_max_partition_id := v_min_partition_id + v_partition_interval;
+        ELSE
+            v_max_partition_id := v_start_control + p_batch_interval;
+        END IF;
+
+    ELSIF p_order = 'DESC' THEN
+        EXECUTE format('SELECT max(%I) FROM ONLY %I.%I', v_control, v_source_schemaname, v_source_tablename) INTO v_start_control;
+        IF v_start_control IS NULL THEN
+            EXIT;
+        END IF;
+        v_min_partition_id := v_start_control - (v_start_control % v_partition_interval);
+        -- Must be greater than max value still in parent table since query below grabs < max
+        v_max_partition_id := v_min_partition_id + v_partition_interval;
+        v_partition_id := ARRAY[v_min_partition_id];
+        -- Make sure minimum doesn't underflow current partition minimum
+        IF (v_start_control - p_batch_interval) >= v_min_partition_id THEN
+            v_min_partition_id := v_start_control - p_batch_interval;
+        END IF;
+    ELSE
+        RAISE EXCEPTION 'Invalid value for p_order. Must be ASC or DESC';
+    END IF;
+
+    -- do some locking with timeout, if required
+    IF p_lock_wait > 0  THEN
+        v_lock_iter := 0;
+        WHILE v_lock_iter <= 5 LOOP
+            v_lock_iter := v_lock_iter + 1;
+            BEGIN
+                v_sql := format('SELECT * FROM ONLY %I.%I WHERE %I >= %s AND %I < %s FOR UPDATE NOWAIT'
+                    , v_source_schemaname
+                    , v_source_tablename
+                    , v_control
+                    , v_min_partition_id
+                    , v_control
+                    , v_max_partition_id);
+                EXECUTE v_sql;
+                v_lock_obtained := TRUE;
+                EXCEPTION
+                WHEN lock_not_available THEN
+                    PERFORM pg_sleep( p_lock_wait / 5.0 );
+                    CONTINUE;
+            END;
+            EXIT WHEN v_lock_obtained;
+        END LOOP;
+        IF NOT v_lock_obtained THEN
+            RETURN -1;
+        END IF;
+    END IF;
+
+    v_current_partition_name := @extschema@.check_name_length(COALESCE(v_parent_tablename), v_min_partition_id::text, TRUE, v_child_table_prefix);
+
+    IF p_override_system_value THEN
+        v_override_statement = ' OVERRIDING SYSTEM VALUE ';
+    ELSE
+        v_override_statement = ' ';
+    END IF;
+
+    IF v_default_exists THEN
+
+        -- Child tables cannot be created if data that belongs to it exists in the default
+        -- Have to move data out to temporary location, create child table, then move it back
+
+        -- Temp table created above to avoid excessive temp creation in loop
+        -- Must use full column list here since the temp table cannot have generated/identity values for defaults.
+        --      This allows for all scenarios where some people may want newly generated values and others may not.
+        --      Those that want them are handled by the filtered column list when moving to the real table
+        EXECUTE format('WITH partition_data AS (
+                DELETE FROM %1$I.%2$I WHERE %3$I >= %4$s AND %3$I < %5$s RETURNING *)
+            INSERT INTO partman_temp_data_storage (%6$s) SELECT %6$s FROM partition_data'
+            , v_source_schemaname
+            , v_source_tablename
+            , v_control
+            , v_min_partition_id
+            , v_max_partition_id
+            , v_column_list_full);
+
+        -- Set analyze to true if a table is created
+        v_analyze := @extschema@.create_partition_id(p_parent_table, v_partition_id);
+
+        EXECUTE format('WITH partition_data AS (
+                DELETE FROM partman_temp_data_storage RETURNING *)
+            INSERT INTO %1$I.%2$I (%3$s) %4$s SELECT %3$s FROM partition_data'
+            , v_parent_schemaname
+            , v_current_partition_name
+            , v_column_list_filtered
+            , v_override_statement);
+
+    ELSE
+
+        -- Set analyze to true if a table is created
+        v_analyze := @extschema@.create_partition_id(p_parent_table, v_partition_id);
+
+        EXECUTE format('WITH partition_data AS (
+                DELETE FROM ONLY %1$I.%2$I WHERE %3$I >= %4$s AND %3$I < %5$s RETURNING *)
+            INSERT INTO %6$I.%7$I (%8$s) %9$s SELECT %8$s FROM partition_data'
+            , v_source_schemaname
+            , v_source_tablename
+            , v_control
+            , v_min_partition_id
+            , v_max_partition_id
+            , v_parent_schemaname
+            , v_current_partition_name
+            , v_column_list_filtered
+            , v_override_statement);
+
+    END IF;
+
+    GET DIAGNOSTICS v_rowcount = ROW_COUNT;
+    v_total_rows := v_total_rows + v_rowcount;
+    IF v_rowcount = 0 THEN
+        EXIT;
+    END IF;
+
+END LOOP;
+
+-- v_analyze is a local check if a new table is made.
+-- p_analyze is a parameter to say whether to run the analyze at all. Used by create_partition() to avoid long exclusive lock or run_maintenence() to avoid long creation runs.
+IF v_analyze AND p_analyze THEN
+    RAISE DEBUG 'partiton_data_time: Begin analyze of %.%', v_parent_schemaname, v_parent_tablename;
+    EXECUTE format('ANALYZE %I.%I', v_parent_schemaname, v_parent_tablename);
+    RAISE DEBUG 'partiton_data_time: End analyze of %.%', v_parent_schemaname, v_parent_tablename;
+END IF;
+
+RETURN v_total_rows;
+
+END
+$$;
+
+
+CREATE OR REPLACE FUNCTION @extschema@.dump_partitioned_table_definition(
+    p_parent_table text,
+    p_ignore_template_table boolean DEFAULT false
+)
+    RETURNS text
+    LANGUAGE PLPGSQL STABLE
+    SET search_path = @extschema@, pg_catalog, pg_temp
+    AS $$
+DECLARE
+    v_automatic_maintenance text;
+    v_create_partition_definition text;
+    v_child_table_prefix text;
+    v_constraint_cols TEXT[];
+    v_constraint_valid boolean;
+    v_control text;
+    v_date_trunc_interval text;
+    v_datetime_string text;
+    v_default_exists boolean;
+    v_default_tablename text;
+    v_detach_before_drop boolean;
+    v_epoch text;
+    v_ignore_default_data boolean;
+    v_infinite_time_partitions boolean;
+    v_inherit_privileges boolean;
+    v_jobmon boolean;
+    v_maintenance_role text;
+    v_maintenance_order int;
+    v_notnull boolean;
+    v_optimize_constraint integer;
+    v_parent_schemaname text;
+    v_parent_tablename text;
+    v_partition_type text;
+    v_partition_interval text;
+    v_premake integer;
+    v_parent_table text;
+    v_retention text;
+    v_retention_keep_publication boolean;
+    v_retention_keep_index boolean;
+    v_retention_keep_table boolean;
+    v_retention_schema text;
+    v_sql text;
+    v_sub_partition_set_full boolean;
+    v_template_table text;
+    v_update_part_config_definition text;
+BEGIN
+    SELECT
+        pc.parent_table
+        , pc.control
+        , pc.partition_type
+        , pc.partition_interval
+        , pc.constraint_cols
+        , pc.premake
+        , pc.optimize_constraint
+        , pc.epoch
+        , pc.retention
+        , pc.retention_schema
+        , pc.retention_keep_index
+        , pc.retention_keep_table
+        , pc.infinite_time_partitions
+        , pc.datetime_string
+        , pc.automatic_maintenance
+        , pc.jobmon
+        , pc.sub_partition_set_full
+        , pc.template_table
+        , pc.inherit_privileges
+        , pc.constraint_valid
+        , pc.ignore_default_data
+        , pc.date_trunc_interval
+        , pc.maintenance_order
+        , pc.retention_keep_publication
+        , pc.detach_before_drop
+        , pc.maintenance_role
+        , pc.child_table_prefix
+    INTO
+        v_parent_table
+        , v_control
+        , v_partition_type
+        , v_partition_interval
+        , v_constraint_cols
+        , v_premake
+        , v_optimize_constraint
+        , v_epoch
+        , v_retention
+        , v_retention_schema
+        , v_retention_keep_index
+        , v_retention_keep_table
+        , v_infinite_time_partitions
+        , v_datetime_string
+        , v_automatic_maintenance
+        , v_jobmon
+        , v_sub_partition_set_full
+        , v_template_table
+        , v_inherit_privileges
+        , v_constraint_valid
+        , v_ignore_default_data
+        , v_date_trunc_interval
+        , v_maintenance_order
+        , v_retention_keep_publication
+        , v_detach_before_drop
+        , v_maintenance_role
+        , v_child_table_prefix
+    FROM @extschema@.part_config pc
+    WHERE pc.parent_table = p_parent_table;
+
+    IF v_parent_table IS NULL THEN
+        RAISE EXCEPTION 'Given parent table not found in pg_partman configuration table: %', p_parent_table;
+    END IF;
+
+    IF p_ignore_template_table THEN
+        v_template_table := NULL;
+    END IF;
+
+    SELECT schemaname, tablename
+    INTO v_parent_schemaname, v_parent_tablename
+    FROM pg_catalog.pg_tables
+    WHERE schemaname = split_part(p_parent_table, '.', 1)::name
+    AND tablename = split_part(p_parent_table, '.', 2)::name;
+
+    -- Check to see if table has a default
+    v_sql := format('SELECT c.relname
+            FROM pg_catalog.pg_inherits h
+            JOIN pg_catalog.pg_class c ON c.oid = h.inhrelid
+            JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
+            WHERE h.inhparent = ''%I.%I''::regclass
+            AND pg_get_expr(relpartbound, c.oid) = ''DEFAULT'''
+        , v_parent_schemaname
+        , v_parent_tablename);
+
+    EXECUTE v_sql INTO v_default_tablename;
+    IF v_default_tablename IS NOT NULL THEN
+        v_default_exists := true;
+    ELSE
+        v_default_exists := false;
+    END IF;
+
+    SELECT attnotnull INTO v_notnull
+    FROM pg_catalog.pg_attribute a
+    JOIN pg_catalog.pg_class c ON a.attrelid = c.oid
+    JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
+    WHERE c.relname = v_parent_tablename::name
+    AND n.nspname = v_parent_schemaname::name
+    AND a.attname = v_control::name;
+
+    v_create_partition_definition := format(
+E'SELECT @extschema@.create_partition(
+\tp_parent_table := %L,
+\tp_control := %L,
+\tp_interval := %L,
+\tp_type := %L,
+\tp_epoch := %L,
+\tp_premake := %s,
+\tp_default_table := %L,
+\tp_automatic_maintenance := %L,
+\tp_constraint_cols := %L,
+\tp_template_table := %L,
+\tp_jobmon := %L,
+\tp_date_trunc_interval := %L,
+\tp_control_not_null := %L
+);',
+            v_parent_table
+            , v_control
+            , v_partition_interval
+            , v_partition_type
+            , v_epoch
+            , v_premake
+            , v_default_exists
+            , v_automatic_maintenance
+            , v_constraint_cols
+            , v_template_table
+            , v_jobmon
+            , v_date_trunc_interval
+            , v_notnull
+        );
+
+    v_update_part_config_definition := format(
+E'UPDATE @extschema@.part_config SET
+\toptimize_constraint = %s,
+\tretention = %L,
+\tretention_schema = %L,
+\tretention_keep_index = %L,
+\tretention_keep_table = %L,
+\tinfinite_time_partitions = %L,
+\tdatetime_string = %L,
+\tsub_partition_set_full = %L,
+\tinherit_privileges = %L,
+\tconstraint_valid = %L,
+\tignore_default_data = %L,
+\tmaintenance_order = %L,
+\tretention_keep_publication = %L,
+\tdetach_before_drop = %L,
+\tmaintenance_role = %L,
+\tchild_table_prefix = %L
+WHERE parent_table = %L;',
+        v_optimize_constraint
+        , v_retention
+        , v_retention_schema
+        , v_retention_keep_index
+        , v_retention_keep_table
+        , v_infinite_time_partitions
+        , v_datetime_string
+        , v_sub_partition_set_full
+        , v_inherit_privileges
+        , v_constraint_valid
+        , v_ignore_default_data
+        , v_maintenance_order
+        , v_retention_keep_publication
+        , v_detach_before_drop
+        , v_maintenance_role
+        , v_child_table_prefix
+        , v_parent_table
+    );
+
+    RETURN concat_ws(E'\n',
+        v_create_partition_definition
+        , v_update_part_config_definition
+    );
+END
+$$;
+
+
+


### PR DESCRIPTION
Updated the logic for determining suffixes of partitioned tables. 

Previous implementation always appended '_p' for partitioned tables:

    v_suffix := format('%s%s', CASE WHEN p_table_partition THEN '_p' END, p_suffix);

New logic allows using a simple naming convention for child tables without affecting existing behavior:

    v_suffix := format('%s%s',
        CASE
            WHEN p_table_partition AND p_simple_naming THEN '_'
            WHEN p_table_partition THEN '_p'
        END,
        p_suffix
    );

This change enables specifying a custom prefix/suffix for child table names (via `p_suffix`) while preserving the original '_p' behavior for partitions that do not use simple naming. It makes the code more flexible without breaking existing functionality.