### PR TITLE
Fix RANGE->LIST subpartitioning in create_partition_time()

### DIFF
--- a/sql/functions/create_partition_time.sql
+++ b/sql/functions/create_partition_time.sql
@@ -190,6 +190,8 @@ FOREACH v_time IN ARRAY p_partition_times LOOP
     WHERE sub_parent = p_parent_table;
     IF v_sub_partition_type = 'range' THEN
         v_sql :=  format('%s PARTITION BY RANGE (%I) ', v_sql, v_sub_control);
+    ELSIF v_sub_partition_type = 'list' THEN
+        v_sql := format('%s PARTITION BY LIST (%I) ', v_sql, v_sub_control);
     END IF;
 
     RAISE DEBUG 'create_partition_time v_sql: %', v_sql;


### PR DESCRIPTION
create_partition_time() only appended "PARTITION BY RANGE" clause when recreating child tables for subpartitioning, but did not handle the LIST case. This caused create_sub_parent() to fail with: "ERROR: You must have created the given parent table as ranged or list partitioned already."

Fixes #855