### PR TITLE
Fix SQL format string for partition selection

### DIFF
--- a/sql/functions/partition_data_time.sql
+++ b/sql/functions/partition_data_time.sql
@@ -276,7 +276,7 @@ FOR i IN 1..p_batch_count LOOP
         WHILE v_lock_iter <= 5 LOOP
             v_lock_iter := v_lock_iter + 1;
             BEGIN
-                v_sql := format('SELECT * FROM ONLY %I.%I WHERE %s >= %L AND %4$s < %6$L FOR UPDATE NOWAIT'
+                v_sql := format('SELECT * FROM ONLY %I.%I WHERE %s >= %L AND %3$s < %5$L FOR UPDATE NOWAIT'
                     , v_source_schemaname
                     , v_source_tablename
                     , v_partition_expression


### PR DESCRIPTION
## Summary

Fixes #862 — `ERROR: too few arguments for format()` in `partition_data_time()`.

## Root Cause

The `format()` call that builds the row-locking query uses explicit  positional references (`%4$s`, `%6$L`). At some point `v_column_list` was  removed as the first argument to this call, shifting all subsequent  argument positions down by one — but the explicit references were never  updated to match, leaving `%6$L` pointing to a 6th argument that no longer  exists.

## Fix

```sql
-- Before:
'SELECT * FROM ONLY %I.%I WHERE %s >= %L AND %4$s < %6$L FOR UPDATE NOWAIT'

-- After:
'SELECT * FROM ONLY %I.%I WHERE %s >= %L AND %3$s < %5$L FOR UPDATE NOWAIT'
```

`%3$s` now correctly points to `v_partition_expression` and `%5$L` to  `v_max_partition_timestamp`, matching their actual positions in the current  5-argument list.

## Testing

Reproduced and fixed on pg_partman 5.3.1 by calling `partition_data_proc()`  to move data out of the DEFAULT partition on a monthly time-based set.  Fails consistently before the fix, works correctly after.