### PR TITLE
fix: align time partition boundaries to the set's timezone (#865)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+5.4.4
+=====
+BUGFIXES
+--------
+ - Fix time-based partition boundaries drifting when `run_maintenance()` is run from a session timezone different from the one the partition set was created in (e.g. a set aligned to a non-UTC timezone maintained from a UTC client such as DataGrip). Timestamptz boundary math is now done in the partition set's own timezone. A new `part_config.partition_timezone` column records the timezone at creation time (defaults to the creating session's timezone); existing sets with a NULL value keep the previous session-timezone behavior until the column is set. (Github Issue #865)
+
+NEW FEATURES
+------------
+ - `create_parent()` / `create_partition()` accept a new optional `p_timezone` parameter to explicitly set the timezone a time-based partition set is aligned to.
+
+
 5.4.3
 =====
 NEW FEATURES

--- a/META.json
+++ b/META.json
@@ -1,7 +1,7 @@
 {
     "name": "pg_partman",
     "abstract": "Extension to manage partitioned tables by time or ID",
-    "version": "5.4.3",
+    "version": "5.4.4",
     "maintainer": [
         "Keith Fiske <keith@keithf4.com>"
     ],
@@ -20,9 +20,9 @@
     },
     "provides": {
         "pg_partman": {
-            "file": "sql/pg_partman--5.4.3.sql",
+            "file": "sql/pg_partman--5.4.4.sql",
             "docfile": "doc/pg_partman.md",
-            "version": "5.4.3",
+            "version": "5.4.4",
             "abstract": "Extension to manage partitioned tables by time or ID"
         }
     },

--- a/pg_partman.control
+++ b/pg_partman.control
@@ -1,4 +1,4 @@
-default_version = '5.4.3'
+default_version = '5.4.4'
 comment = 'Extension to manage partitioned tables by time or ID'
 relocatable = false
 superuser = false

--- a/sql/functions/calculate_time_partition_info.sql
+++ b/sql/functions/calculate_time_partition_info.sql
@@ -2,6 +2,7 @@ CREATE FUNCTION @extschema@.calculate_time_partition_info(
         p_time_interval interval
         , p_start_time timestamptz
         , p_date_trunc_interval text DEFAULT NULL
+        , p_timezone text DEFAULT NULL
         , OUT base_timestamp timestamptz
         , OUT datetime_string text
 )
@@ -9,6 +10,10 @@ CREATE FUNCTION @extschema@.calculate_time_partition_info(
     LANGUAGE plpgsql STABLE
     SET search_path = @extschema@, pg_catalog, pg_temp
     AS $$
+DECLARE
+
+v_timezone  text := COALESCE(p_timezone, current_setting('TimeZone'));
+
 BEGIN
 
 -- Built-in datetime string suffixes are YYYYMMDD, YYYYMMDD_HH24MISS
@@ -17,31 +22,36 @@ IF p_time_interval < '1 day' THEN
     datetime_string := datetime_string || '_HH24MISS';
 END IF;
 
+-- Truncation is done in the partition set's own timezone (v_timezone) so that
+-- boundaries stay aligned regardless of the session timezone maintenance runs
+-- in. When p_timezone is NULL the current session timezone is used, which is
+-- exactly the historical behavior. See date_trunc() below via AT TIME ZONE.
+
 IF p_date_trunc_interval IS NOT NULL THEN
-    base_timestamp := date_trunc(p_date_trunc_interval, p_start_time);
+    base_timestamp := date_trunc(p_date_trunc_interval, p_start_time AT TIME ZONE v_timezone) AT TIME ZONE v_timezone;
 
 ELSE
     IF p_time_interval >= '1 year' THEN
-        base_timestamp := date_trunc('year', p_start_time);
+        base_timestamp := date_trunc('year', p_start_time AT TIME ZONE v_timezone) AT TIME ZONE v_timezone;
         IF p_time_interval >= '10 years' THEN
-            base_timestamp := date_trunc('decade', p_start_time);
+            base_timestamp := date_trunc('decade', p_start_time AT TIME ZONE v_timezone) AT TIME ZONE v_timezone;
             IF p_time_interval >= '100 years' THEN
-                base_timestamp := date_trunc('century', p_start_time);
+                base_timestamp := date_trunc('century', p_start_time AT TIME ZONE v_timezone) AT TIME ZONE v_timezone;
                 IF p_time_interval >= '1000 years' THEN
-                    base_timestamp := date_trunc('millennium', p_start_time);
+                    base_timestamp := date_trunc('millennium', p_start_time AT TIME ZONE v_timezone) AT TIME ZONE v_timezone;
                 END IF; -- 1000
             END IF; -- 100
         END IF; -- 10
     END IF; -- 1
 
     IF p_time_interval < '1 year' THEN
-        base_timestamp := date_trunc('month', p_start_time);
+        base_timestamp := date_trunc('month', p_start_time AT TIME ZONE v_timezone) AT TIME ZONE v_timezone;
         IF p_time_interval < '1 month' THEN
-            base_timestamp := date_trunc('day', p_start_time);
+            base_timestamp := date_trunc('day', p_start_time AT TIME ZONE v_timezone) AT TIME ZONE v_timezone;
             IF p_time_interval < '1 day' THEN
-                base_timestamp := date_trunc('hour', p_start_time);
+                base_timestamp := date_trunc('hour', p_start_time AT TIME ZONE v_timezone) AT TIME ZONE v_timezone;
                 IF p_time_interval < '1 minute' THEN
-                    base_timestamp := date_trunc('minute', p_start_time);
+                    base_timestamp := date_trunc('minute', p_start_time AT TIME ZONE v_timezone) AT TIME ZONE v_timezone;
                 END IF; -- minute
             END IF; -- day
         END IF; -- month

--- a/sql/functions/create_parent.sql
+++ b/sql/functions/create_parent.sql
@@ -16,6 +16,7 @@ CREATE FUNCTION @extschema@.create_parent(
     , p_time_encoder text DEFAULT NULL
     , p_time_decoder text DEFAULT NULL
     , p_offset_id bigint DEFAULT 0
+    , p_timezone text DEFAULT NULL
 )
     RETURNS boolean
     LANGUAGE plpgsql
@@ -46,6 +47,7 @@ RETURN @extschema@.create_partition(
     , p_time_encoder
     , p_time_decoder
     , p_offset_id
+    , p_timezone
 );
 
 END

--- a/sql/functions/create_partition.sql
+++ b/sql/functions/create_partition.sql
@@ -16,6 +16,7 @@ CREATE FUNCTION @extschema@.create_partition(
     , p_time_encoder text DEFAULT NULL
     , p_time_decoder text DEFAULT NULL
     , p_offset_id bigint DEFAULT 0
+    , p_timezone text DEFAULT NULL
 )
     RETURNS boolean
     LANGUAGE plpgsql
@@ -55,6 +56,7 @@ v_parent_tablename              text;
 v_parent_tablespace             name;
 v_part_col                      text;
 v_part_type                     text;
+v_partition_timezone            text;
 v_partattrs                     smallint[];
 v_partition_time                timestamptz;
 v_partition_time_array          timestamptz[];
@@ -337,12 +339,17 @@ IF v_control_type IN ('time', 'text', 'uuid') OR (v_control_type = 'id' AND p_ep
         RAISE EXCEPTION 'Partitioning interval must be 1 second or greater';
     END IF;
 
+    -- Capture the timezone the set is aligned to (defaults to the creating
+    -- session's timezone). Stored in part_config so run_maintenance() keeps
+    -- future boundaries aligned regardless of the session it runs in.
+    v_partition_timezone := COALESCE(p_timezone, current_setting('TimeZone'));
+
    -- First partition is either the min premake or p_start_partition
     v_start_time := COALESCE(p_start_partition::timestamptz, CURRENT_TIMESTAMP - (v_time_interval * p_premake));
 
     SELECT base_timestamp, datetime_string
     INTO v_base_timestamp, v_datetime_string
-    FROM @extschema@.calculate_time_partition_info(v_time_interval, v_start_time, p_date_trunc_interval);
+    FROM @extschema@.calculate_time_partition_info(v_time_interval, v_start_time, p_date_trunc_interval, v_partition_timezone);
 
     RAISE DEBUG '(): parent_table: %, v_base_timestamp: %', p_parent_table, v_base_timestamp;
 
@@ -382,7 +389,8 @@ IF v_control_type IN ('time', 'text', 'uuid') OR (v_control_type = 'id' AND p_ep
         , jobmon
         , template_table
         , inherit_privileges
-        , date_trunc_interval)
+        , date_trunc_interval
+        , partition_timezone)
     VALUES (
         p_parent_table
         , p_type
@@ -398,7 +406,8 @@ IF v_control_type IN ('time', 'text', 'uuid') OR (v_control_type = 'id' AND p_ep
         , p_jobmon
         , v_template_schema||'.'||v_template_tablename
         , v_inherit_privileges
-        , p_date_trunc_interval);
+        , p_date_trunc_interval
+        , v_partition_timezone);
 
     RAISE DEBUG ': v_partition_time_array: %', v_partition_time_array;
 

--- a/sql/functions/create_partition_time.sql
+++ b/sql/functions/create_partition_time.sql
@@ -48,6 +48,8 @@ v_template_table                text;
 v_time                          timestamptz;
 v_partition_text_start          text;
 v_partition_text_end            text;
+v_partition_timezone            text;
+v_timezone                      text;
 
 BEGIN
 /*
@@ -62,6 +64,7 @@ SELECT control
     , datetime_string
     , template_table
     , inherit_privileges
+    , partition_timezone
 INTO v_control
     , v_time_encoder
     , v_partition_interval
@@ -70,12 +73,18 @@ INTO v_control
     , v_datetime_string
     , v_template_table
     , v_inherit_privileges
+    , v_partition_timezone
 FROM @extschema@.part_config
 WHERE parent_table = p_parent_table;
 
 IF NOT FOUND THEN
     RAISE EXCEPTION 'ERROR: no config found for %', p_parent_table;
 END IF;
+
+-- Boundary end and child name suffix are computed in the set's own timezone so
+-- they stay aligned regardless of the session timezone. NULL falls back to the
+-- session timezone, preserving historical behavior.
+v_timezone := COALESCE(v_partition_timezone, current_setting('TimeZone'));
 
 SELECT n.nspname
     , c.relname
@@ -128,7 +137,7 @@ RAISE DEBUG 'create_partition_time: v_partition_expression: %', v_partition_expr
 FOREACH v_time IN ARRAY p_partition_times LOOP
     v_partition_timestamp_start := v_time;
     BEGIN
-        v_partition_timestamp_end := v_time + v_partition_interval;
+        v_partition_timestamp_end := (v_time AT TIME ZONE v_timezone + v_partition_interval) AT TIME ZONE v_timezone;
     EXCEPTION WHEN datetime_field_overflow THEN
         RAISE WARNING 'Attempted partition time interval is outside PostgreSQL''s supported time range.
             Child partition creation after time % skipped', v_time;
@@ -150,7 +159,7 @@ FOREACH v_time IN ARRAY p_partition_times LOOP
     END IF;
 
     -- This suffix generation code is in partition_data_time() as well
-    v_partition_suffix := to_char(v_time, v_datetime_string);
+    v_partition_suffix := to_char(v_time AT TIME ZONE v_timezone, v_datetime_string);
     v_partition_name := @extschema@.check_name_length(v_parent_tablename, v_partition_suffix, TRUE);
     -- Check if child exists.
     SELECT count(*) INTO v_exists

--- a/sql/functions/dump_partitioned_table_definition.sql
+++ b/sql/functions/dump_partitioned_table_definition.sql
@@ -34,6 +34,7 @@ DECLARE
     v_date_trunc_interval text;
     v_maintenance_order int;
     v_retention_keep_publication boolean;
+    v_partition_timezone text;
     v_parent_schemaname text;
     v_parent_tablename text;
     v_default_exists boolean;
@@ -65,7 +66,8 @@ BEGIN
         pc.ignore_default_data,
         pc.date_trunc_interval,
         pc.maintenance_order,
-        pc.retention_keep_publication
+        pc.retention_keep_publication,
+        pc.partition_timezone
     INTO
         v_parent_table,
         v_control,
@@ -90,7 +92,8 @@ BEGIN
         v_ignore_default_data,
         v_date_trunc_interval,
         v_maintenance_order,
-        v_retention_keep_publication
+        v_retention_keep_publication,
+        v_partition_timezone
     FROM @extschema@.part_config pc
     WHERE pc.parent_table = p_parent_table;
 
@@ -147,7 +150,8 @@ E'SELECT @extschema@.create_partition(
 \tp_template_table := %L,
 \tp_jobmon := %L,
 \tp_date_trunc_interval := %L,
-\tp_control_not_null := %L
+\tp_control_not_null := %L,
+\tp_timezone := %L
 );',
             v_parent_table,
             v_control,
@@ -161,7 +165,8 @@ E'SELECT @extschema@.create_partition(
             v_template_table,
             v_jobmon,
             v_date_trunc_interval,
-            v_notnull
+            v_notnull,
+            v_partition_timezone
         );
 
     v_update_part_config_definition := format(

--- a/sql/functions/run_maintenance.sql
+++ b/sql/functions/run_maintenance.sql
@@ -64,6 +64,7 @@ v_sub_timestamp_max             timestamptz;
 v_sub_timestamp_max_suffix      timestamptz;
 v_sub_timestamp_min             timestamptz;
 v_tables_list_sql               text;
+v_timezone                      text;
 
 BEGIN
 /*
@@ -131,6 +132,7 @@ v_tables_list_sql := 'SELECT parent_table
                 , maintenance_order
                 , date_trunc_interval
                 , async_partitioning_in_progress
+                , partition_timezone
             FROM @extschema@.part_config
             WHERE undo_in_progress = false';
 
@@ -219,6 +221,12 @@ LOOP
     END;
     RAISE DEBUG 'run_maint: v_partition_expression: %', v_partition_expression;
 
+    -- All timestamptz boundary math below is done in the partition set's own
+    -- timezone so boundaries stay aligned no matter which session timezone
+    -- maintenance is invoked from. A NULL partition_timezone falls back to the
+    -- session timezone, preserving the historical behavior.
+    v_timezone := COALESCE(v_row.partition_timezone, current_setting('TimeZone'));
+
     SELECT partition_tablename INTO v_last_partition FROM @extschema@.show_partitions(v_row.parent_table, 'DESC') LIMIT 1;
     RAISE DEBUG 'run_maint: parent_table: %, v_last_partition: %', v_row.parent_table, v_last_partition;
 
@@ -239,7 +247,7 @@ LOOP
             -- Need to properly truncate the interval and account for custom date truncation
             SELECT base_timestamp
             INTO v_last_partition_timestamp
-            FROM @extschema@.calculate_time_partition_info(v_row.partition_interval::interval, v_last_partition_timestamp, v_row.date_trunc_interval);
+            FROM @extschema@.calculate_time_partition_info(v_row.partition_interval::interval, v_last_partition_timestamp, v_row.date_trunc_interval, v_timezone);
         END IF;
 
         -- Must be reset to null otherwise if the next partition set in the loop is empty, the previous partition set's value could be used
@@ -338,7 +346,10 @@ LOOP
                 EXIT;
             END IF;
             BEGIN
-                v_next_partition_timestamp := v_next_partition_timestamp + v_row.partition_interval::interval;
+                -- Advance in the set's timezone so month/year intervals land on
+                -- the same wall-clock boundary (e.g. the 1st at 00:00) instead
+                -- of drifting when the session timezone differs from the set's.
+                v_next_partition_timestamp := (v_next_partition_timestamp AT TIME ZONE v_timezone + v_row.partition_interval::interval) AT TIME ZONE v_timezone;
             EXCEPTION WHEN datetime_field_overflow THEN
                 v_premade_count := v_row.premake; -- do this so it can exit the premake check loop and continue in the outer for loop
                 IF v_jobmon_schema IS NOT NULL THEN

--- a/sql/tables/tables.sql
+++ b/sql/tables/tables.sql
@@ -28,6 +28,7 @@ CREATE TABLE @extschema@.part_config (
     , retention_keep_publication boolean NOT NULL DEFAULT false
     , maintenance_last_run timestamptz
     , async_partitioning_in_progress text
+    , partition_timezone text
     , CONSTRAINT part_config_parent_table_pkey PRIMARY KEY (parent_table)
     , CONSTRAINT positive_premake_check CHECK (premake > 0)
 );

--- a/test/test-dump-definition.sql
+++ b/test/test-dump-definition.sql
@@ -44,7 +44,8 @@ SELECT bag_eq(
     'maintenance_order',
     'retention_keep_publication',
     'maintenance_last_run',
-    'async_partitioning_in_progress'
+    'async_partitioning_in_progress',
+    'partition_timezone'
   ]::TEXT[],
   'When adding a new column to part_config please ensure it is also added to the dump_partitioned_table_definition function and the tests in this file'
 );
@@ -58,8 +59,10 @@ CREATE TABLE partman_test.declarative_objects(
 ) PARTITION BY RANGE (created_at);
 SELECT create_partition('partman_test.declarative_objects', 'created_at', '1 week', p_premake := 2, p_start_partition := (NOW() - '4 weeks'::INTERVAL)::TEXT);
 -- Update config options you can't set at initial creation.
+-- partition_timezone is pinned here so the dump output is deterministic
+-- regardless of the session timezone the test runs in.
 UPDATE part_config
-SET retention='5 weeks', retention_keep_table = 'f', infinite_time_partitions = 't', constraint_valid = 'f', inherit_privileges = 't'
+SET retention='5 weeks', retention_keep_table = 'f', infinite_time_partitions = 't', constraint_valid = 'f', inherit_privileges = 't', partition_timezone = 'UTC'
 WHERE parent_table = 'partman_test.declarative_objects';
 
 -- Test output "visually" (with p_ignore_template_table = true).
@@ -83,7 +86,8 @@ E'SELECT partman.create_partition(
 	p_template_table := ''partman.template_partman_test_declarative_objects'',
 	p_jobmon := ''t'',
 	p_date_trunc_interval := NULL,
-	p_control_not_null := ''t''
+	p_control_not_null := ''t'',
+	p_timezone := ''UTC''
 );
 UPDATE partman.part_config SET
 	optimize_constraint = 30,

--- a/test/test-time-monthly-timezone.sql
+++ b/test/test-time-monthly-timezone.sql
@@ -1,0 +1,74 @@
+-- ########## TIME MONTHLY TIMEZONE ##########
+-- Regression test for boundary drift when run_maintenance() is invoked from a
+-- session timezone different from the one the partition set was created in.
+--
+-- A monthly set is created while the session is in Europe/Moscow (UTC+3), so
+-- every boundary is Moscow local midnight. Maintenance is then run from a UTC
+-- session (as many client drivers, e.g. DataGrip, do by default). The new
+-- child tables must stay aligned to the set's creation timezone; before the
+-- fix their boundaries drifted (e.g. a "December" partition covering Dec 01 ->
+-- Dec 31 and named p<...>1130) because timestamptz month arithmetic was done
+-- in the session timezone.
+
+\set ON_ERROR_ROLLBACK 1
+\set ON_ERROR_STOP true
+
+BEGIN;
+SELECT set_config('search_path','partman, public',false);
+
+SELECT plan(7);
+CREATE SCHEMA partman_test;
+
+SET timezone = 'Europe/Moscow';
+
+CREATE TABLE partman_test.time_taptest_table
+    (col1 bigserial
+     , col3 timestamptz DEFAULT now() NOT NULL)
+    PARTITION BY RANGE (col3);
+
+SELECT create_parent('partman_test.time_taptest_table', 'col3', '1 month', p_premake := 4);
+
+-- A row in the current month so run_maintenance() premakes ahead of "now".
+INSERT INTO partman_test.time_taptest_table (col3) VALUES (CURRENT_TIMESTAMP);
+
+-- The creating session's timezone is recorded so future maintenance stays aligned.
+SELECT results_eq(
+    $$SELECT partition_timezone FROM part_config WHERE parent_table = 'partman_test.time_taptest_table'$$,
+    ARRAY['Europe/Moscow'],
+    'Creation timezone recorded in part_config');
+
+-- Sanity: the last partition created up front is aligned to Moscow midnight.
+SELECT has_table('partman_test', 'time_taptest_table_p'||to_char(date_trunc('month', CURRENT_TIMESTAMP)+'4 months'::interval, 'YYYYMMDD'),
+    'Pre-maintenance: month +4 partition exists');
+
+-- Now a client with UTC (server or driver default) runs maintenance.
+UPDATE part_config SET premake = 6 WHERE parent_table = 'partman_test.time_taptest_table';
+SET timezone = 'UTC';
+SELECT run_maintenance('partman_test.time_taptest_table');
+-- Evaluate expectations back in the creation timezone.
+SET timezone = 'Europe/Moscow';
+
+-- The newly created partitions must keep the Moscow-midnight alignment.
+SELECT has_table('partman_test', 'time_taptest_table_p'||to_char(date_trunc('month', CURRENT_TIMESTAMP)+'5 months'::interval, 'YYYYMMDD'),
+    'Month +5 partition created under UTC session stays aligned to creation tz');
+SELECT has_table('partman_test', 'time_taptest_table_p'||to_char(date_trunc('month', CURRENT_TIMESTAMP)+'6 months'::interval, 'YYYYMMDD'),
+    'Month +6 partition created under UTC session stays aligned to creation tz');
+
+-- Strong check on the actual boundaries, not just the names.
+SELECT results_eq(
+    format($$SELECT child_start_time FROM show_partition_info(%L, '1 month', 'partman_test.time_taptest_table')$$,
+        'partman_test.time_taptest_table_p'||to_char(date_trunc('month', CURRENT_TIMESTAMP)+'5 months'::interval, 'YYYYMMDD')),
+    ARRAY[date_trunc('month', CURRENT_TIMESTAMP)+'5 months'::interval]::timestamptz[],
+    'Month +5 start boundary is Moscow midnight, not shifted');
+SELECT results_eq(
+    format($$SELECT child_start_time FROM show_partition_info(%L, '1 month', 'partman_test.time_taptest_table')$$,
+        'partman_test.time_taptest_table_p'||to_char(date_trunc('month', CURRENT_TIMESTAMP)+'6 months'::interval, 'YYYYMMDD')),
+    ARRAY[date_trunc('month', CURRENT_TIMESTAMP)+'6 months'::interval]::timestamptz[],
+    'Month +6 start boundary is Moscow midnight, not shifted');
+
+-- premake is 6, so no seventh future partition should have been made.
+SELECT hasnt_table('partman_test', 'time_taptest_table_p'||to_char(date_trunc('month', CURRENT_TIMESTAMP)+'7 months'::interval, 'YYYYMMDD'),
+    'Month +7 partition not created (premake honored)');
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/updates/pg_partman--5.4.3--5.4.4.sql
+++ b/updates/pg_partman--5.4.3--5.4.4.sql
@@ -1,0 +1,1960 @@
+-- Update from 5.4.3 to 5.4.4
+-- Fix: keep time-based partition boundaries aligned to the timezone the
+-- partition set was created in, so run_maintenance() no longer shifts
+-- boundaries when invoked from a different session timezone. Adds
+-- part_config.partition_timezone (NULL preserves prior session-tz behavior).
+
+ALTER TABLE @extschema@.part_config ADD COLUMN IF NOT EXISTS partition_timezone text;
+
+-- These functions gained a new p_timezone/p_timezone-derived parameter. Because
+-- adding a defaulted argument via CREATE OR REPLACE would create an additional
+-- overload (and make calls ambiguous), drop the previous signatures first.
+DROP FUNCTION IF EXISTS @extschema@.calculate_time_partition_info(interval, timestamptz, text);
+DROP FUNCTION IF EXISTS @extschema@.create_partition(text, text, text, text, text, int, text, boolean, text, text[], text, boolean, text, boolean, text, text, bigint);
+DROP FUNCTION IF EXISTS @extschema@.create_parent(text, text, text, text, text, int, text, boolean, text, text[], text, boolean, text, boolean, text, text, bigint);
+
+CREATE OR REPLACE FUNCTION @extschema@.calculate_time_partition_info(
+        p_time_interval interval
+        , p_start_time timestamptz
+        , p_date_trunc_interval text DEFAULT NULL
+        , p_timezone text DEFAULT NULL
+        , OUT base_timestamp timestamptz
+        , OUT datetime_string text
+)
+    RETURNS record
+    LANGUAGE plpgsql STABLE
+    SET search_path = @extschema@, pg_catalog, pg_temp
+    AS $$
+DECLARE
+
+v_timezone  text := COALESCE(p_timezone, current_setting('TimeZone'));
+
+BEGIN
+
+-- Built-in datetime string suffixes are YYYYMMDD, YYYYMMDD_HH24MISS
+datetime_string := 'YYYYMMDD';
+IF p_time_interval < '1 day' THEN
+    datetime_string := datetime_string || '_HH24MISS';
+END IF;
+
+-- Truncation is done in the partition set's own timezone (v_timezone) so that
+-- boundaries stay aligned regardless of the session timezone maintenance runs
+-- in. When p_timezone is NULL the current session timezone is used, which is
+-- exactly the historical behavior. See date_trunc() below via AT TIME ZONE.
+
+IF p_date_trunc_interval IS NOT NULL THEN
+    base_timestamp := date_trunc(p_date_trunc_interval, p_start_time AT TIME ZONE v_timezone) AT TIME ZONE v_timezone;
+
+ELSE
+    IF p_time_interval >= '1 year' THEN
+        base_timestamp := date_trunc('year', p_start_time AT TIME ZONE v_timezone) AT TIME ZONE v_timezone;
+        IF p_time_interval >= '10 years' THEN
+            base_timestamp := date_trunc('decade', p_start_time AT TIME ZONE v_timezone) AT TIME ZONE v_timezone;
+            IF p_time_interval >= '100 years' THEN
+                base_timestamp := date_trunc('century', p_start_time AT TIME ZONE v_timezone) AT TIME ZONE v_timezone;
+                IF p_time_interval >= '1000 years' THEN
+                    base_timestamp := date_trunc('millennium', p_start_time AT TIME ZONE v_timezone) AT TIME ZONE v_timezone;
+                END IF; -- 1000
+            END IF; -- 100
+        END IF; -- 10
+    END IF; -- 1
+
+    IF p_time_interval < '1 year' THEN
+        base_timestamp := date_trunc('month', p_start_time AT TIME ZONE v_timezone) AT TIME ZONE v_timezone;
+        IF p_time_interval < '1 month' THEN
+            base_timestamp := date_trunc('day', p_start_time AT TIME ZONE v_timezone) AT TIME ZONE v_timezone;
+            IF p_time_interval < '1 day' THEN
+                base_timestamp := date_trunc('hour', p_start_time AT TIME ZONE v_timezone) AT TIME ZONE v_timezone;
+                IF p_time_interval < '1 minute' THEN
+                    base_timestamp := date_trunc('minute', p_start_time AT TIME ZONE v_timezone) AT TIME ZONE v_timezone;
+                END IF; -- minute
+            END IF; -- day
+        END IF; -- month
+    END IF; -- year
+
+END IF;
+END
+$$;
+
+CREATE OR REPLACE FUNCTION @extschema@.create_partition(
+    p_parent_table text
+    , p_control text
+    , p_interval text
+    , p_type text DEFAULT 'range'
+    , p_epoch text DEFAULT 'none'
+    , p_premake int DEFAULT 4
+    , p_start_partition text DEFAULT NULL
+    , p_default_table boolean DEFAULT true
+    , p_automatic_maintenance text DEFAULT 'on'
+    , p_constraint_cols text[] DEFAULT NULL
+    , p_template_table text DEFAULT NULL
+    , p_jobmon boolean DEFAULT true
+    , p_date_trunc_interval text DEFAULT NULL
+    , p_control_not_null boolean DEFAULT true
+    , p_time_encoder text DEFAULT NULL
+    , p_time_decoder text DEFAULT NULL
+    , p_offset_id bigint DEFAULT 0
+    , p_timezone text DEFAULT NULL
+)
+    RETURNS boolean
+    LANGUAGE plpgsql
+    SET search_path = @extschema@, pg_catalog, pg_temp
+    AS $$
+DECLARE
+
+ex_context                      text;
+ex_detail                       text;
+ex_hint                         text;
+ex_message                      text;
+v_base_timestamp                timestamptz;
+v_count                         int := 1;
+v_control_type                  text;
+v_control_exact_type            text;
+v_datetime_string               text;
+v_default_partition             text;
+v_higher_control_type           text;
+v_higher_parent_control         text;
+v_higher_parent_epoch           text;
+v_higher_parent_schema          text := split_part(p_parent_table, '.', 1);
+v_higher_parent_table           text := split_part(p_parent_table, '.', 2);
+v_id_interval                   bigint;
+v_inherit_privileges            boolean := false; -- This is false by default so initial partition set creation doesn't require superuser.
+v_job_id                        bigint;
+v_jobmon_schema                 text;
+v_last_partition_created        boolean;
+v_max                           bigint;
+v_notnull                       boolean;
+v_new_search_path               text;
+v_old_search_path               text;
+v_parent_owner                  text;
+v_parent_partition_id           bigint;
+v_parent_partition_timestamp    timestamptz;
+v_parent_schemaname                 text;
+v_parent_tablename              text;
+v_parent_tablespace             name;
+v_part_col                      text;
+v_part_type                     text;
+v_partition_timezone            text;
+v_partattrs                     smallint[];
+v_partition_time                timestamptz;
+v_partition_time_array          timestamptz[];
+v_partition_id_array            bigint[];
+v_partstrat                     char;
+v_row                           record;
+v_sql                           text;
+v_start_time                    timestamptz;
+v_starting_partition_id         bigint;
+v_step_id                       bigint;
+v_step_overflow_id              bigint;
+v_success                       boolean := false;
+v_template_schema               text;
+v_template_tablename            text;
+v_time_interval                 interval;
+v_top_parent_schema             text := split_part(p_parent_table, '.', 1);
+v_top_parent_table              text := split_part(p_parent_table, '.', 2);
+v_unlogged                      char;
+
+BEGIN
+/*
+ * Function to turn a table into the parent of a partition set
+ * IMPORTANT: Do not forget to update parameters for create_parent() if they change in this function
+ */
+
+IF array_length(string_to_array(p_parent_table, '.'), 1) < 2 THEN
+    RAISE EXCEPTION 'Parent table must be schema qualified';
+ELSIF array_length(string_to_array(p_parent_table, '.'), 1) > 2 THEN
+    RAISE EXCEPTION 'pg_partman does not support objects with periods in their names';
+END IF;
+
+IF p_interval = 'yearly'
+    OR p_interval = 'quarterly'
+    OR p_interval = 'monthly'
+    OR p_interval  = 'weekly'
+    OR p_interval = 'daily'
+    OR p_interval = 'hourly'
+    OR p_interval = 'half-hour'
+    OR p_interval = 'quarter-hour'
+THEN
+    RAISE EXCEPTION 'Special partition interval values from old pg_partman versions (%) are no longer supported. Please use a supported interval time value from core PostgreSQL (https://www.postgresql.org/docs/current/datatype-datetime.html#DATATYPE-INTERVAL-INPUT)', p_interval;
+END IF;
+
+SELECT n.nspname
+    , c.relname
+    , t.spcname
+INTO v_parent_schemaname
+    , v_parent_tablename
+    , v_parent_tablespace
+FROM pg_catalog.pg_class c
+JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
+LEFT OUTER JOIN pg_catalog.pg_tablespace t ON c.reltablespace = t.oid
+WHERE n.nspname = split_part(p_parent_table, '.', 1)::name
+AND c.relname = split_part(p_parent_table, '.', 2)::name;
+    IF v_parent_tablename IS NULL THEN
+        RAISE EXCEPTION 'Unable to find given parent table in system catalogs. Please create parent table first: %', p_parent_table;
+    END IF;
+
+SELECT attnotnull INTO v_notnull
+FROM pg_catalog.pg_attribute a
+JOIN pg_catalog.pg_class c ON a.attrelid = c.oid
+JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
+WHERE c.relname = v_parent_tablename::name
+AND n.nspname = v_parent_schemaname::name
+AND a.attname = p_control::name;
+    IF (v_notnull IS NULL) THEN
+        RAISE EXCEPTION 'Control column given (%) for parent table (%) does not exist', p_control, p_parent_table;
+    ELSIF (v_notnull = false and p_control_not_null = true) THEN
+        RAISE EXCEPTION 'Control column given (%) for parent table (%) must be set to NOT NULL', p_control, p_parent_table;
+    END IF;
+
+SELECT general_type, exact_type INTO v_control_type, v_control_exact_type
+FROM @extschema@.check_control_type(v_parent_schemaname, v_parent_tablename, p_control);
+
+IF v_control_type IS NULL THEN
+    RAISE EXCEPTION 'pg_partman only supports partitioning of data types that are integer, numeric, date/timestamp or specially encoded text. Supplied column is of type %', v_control_exact_type;
+END IF;
+
+IF (p_epoch <> 'none' AND v_control_type <> 'id') THEN
+    RAISE EXCEPTION 'p_epoch can only be used with an integer based control column';
+END IF;
+
+
+IF NOT @extschema@.check_partition_type(p_type) THEN
+    RAISE EXCEPTION '% is not a valid partitioning type for pg_partman', p_type;
+END IF;
+
+IF current_setting('server_version_num')::int < 140000 THEN
+    RAISE EXCEPTION 'pg_partman requires PostgreSQL 14 or greater';
+END IF;
+-- Check if given parent table has been already set up as a partitioned table
+SELECT p.partstrat
+    , p.partattrs
+INTO v_partstrat
+    , v_partattrs
+FROM pg_catalog.pg_partitioned_table p
+JOIN pg_catalog.pg_class c ON p.partrelid = c.oid
+JOIN pg_namespace n ON c.relnamespace = n.oid
+WHERE n.nspname = v_parent_schemaname::name
+AND c.relname = v_parent_tablename::name;
+
+IF v_partstrat NOT IN ('r', 'l') OR v_partstrat IS NULL THEN
+    RAISE EXCEPTION 'You must have created the given parent table as ranged or list partitioned already. Ex: CREATE TABLE ... PARTITION BY [RANGE|LIST] ...)';
+END IF;
+
+IF array_length(v_partattrs, 1) > 1 THEN
+    RAISE NOTICE 'pg_partman only supports single column partitioning at this time. Found % columns in given parent definition.', array_length(v_partattrs, 1);
+END IF;
+
+SELECT a.attname, t.typname
+INTO v_part_col, v_part_type
+FROM pg_attribute a
+JOIN pg_class c ON a.attrelid = c.oid
+JOIN pg_namespace n ON c.relnamespace = n.oid
+JOIN pg_type t ON a.atttypid = t.oid
+WHERE n.nspname = v_parent_schemaname::name
+AND c.relname = v_parent_tablename::name
+AND attnum IN (SELECT unnest(partattrs) FROM pg_partitioned_table p WHERE a.attrelid = p.partrelid);
+
+IF p_control <> v_part_col OR v_control_exact_type <> v_part_type THEN
+    RAISE EXCEPTION 'Control column and type given in arguments (%, %) does not match the control column and type of the given partition set (%, %)', p_control, v_control_exact_type, v_part_col, v_part_type;
+END IF;
+
+-- Check that control column is a usable type for pg_partman.
+IF v_control_type NOT IN ('time', 'id', 'text', 'uuid') THEN
+    RAISE EXCEPTION 'Only date/time, text/uuid or integer types are allowed for the control column.';
+ELSIF v_control_type IN ('text', 'uuid') AND (p_time_encoder IS NULL OR p_time_decoder IS NULL) THEN
+    RAISE EXCEPTION 'p_time_encoder and p_time_decoder needs to be set for text/uuid type control column.';
+ELSIF v_control_type NOT IN ('text', 'uuid') AND (p_time_encoder IS NOT NULL OR p_time_decoder IS NOT NULL) THEN
+    RAISE EXCEPTION 'p_time_encoder and p_time_decoder can only be used with text/uuid type control column.';
+END IF;
+
+-- Table to handle properties not managed by core PostgreSQL yet
+IF p_template_table IS NULL THEN
+    v_template_schema := '@extschema@';
+    v_template_tablename := @extschema@.check_name_length('template_'||v_parent_schemaname||'_'||v_parent_tablename);
+    EXECUTE format('CREATE TABLE IF NOT EXISTS %I.%I (LIKE %I.%I)', v_template_schema, v_template_tablename, v_parent_schemaname, v_parent_tablename);
+
+    SELECT pg_get_userbyid(c.relowner) INTO v_parent_owner
+    FROM pg_catalog.pg_class c
+    JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
+    WHERE n.nspname = v_parent_schemaname::name
+    AND c.relname = v_parent_tablename::name;
+
+    EXECUTE format('ALTER TABLE %s.%I OWNER TO %I'
+            , '@extschema@'
+            , v_template_tablename
+            , v_parent_owner);
+ELSIF lower(p_template_table) IN ('false', 'f') THEN
+    v_template_schema := NULL;
+    v_template_tablename := NULL;
+    RAISE DEBUG 'create_partition(): parent_table: %, skipped template table creation', p_parent_table;
+ELSE
+    SELECT n.nspname, c.relname INTO v_template_schema, v_template_tablename
+    FROM pg_catalog.pg_class c
+    JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
+    WHERE n.nspname = split_part(p_template_table, '.', 1)::name
+    AND c.relname = split_part(p_template_table, '.', 2)::name;
+        IF v_template_tablename IS NULL THEN
+            RAISE EXCEPTION 'Unable to find given template table in system catalogs (%). Please create template table first or leave parameter NULL to have a default one created for you.', p_parent_table;
+        END IF;
+END IF;
+
+IF p_jobmon THEN
+    SELECT nspname INTO v_jobmon_schema FROM pg_catalog.pg_namespace n, pg_catalog.pg_extension e WHERE e.extname = 'pg_jobmon'::name AND e.extnamespace = n.oid;
+    IF v_jobmon_schema IS NOT NULL THEN
+        SELECT current_setting('search_path') INTO v_old_search_path;
+        IF v_jobmon_schema IS NOT NULL THEN
+            v_new_search_path := format('%s,%s',v_jobmon_schema, v_old_search_path);
+            EXECUTE format('SET LOCAL search_path TO %s', v_new_search_path);
+        END IF;
+    END IF;
+END IF;
+
+EXECUTE format('LOCK TABLE %I.%I IN ACCESS EXCLUSIVE MODE', v_parent_schemaname, v_parent_tablename);
+
+IF v_jobmon_schema IS NOT NULL THEN
+    v_job_id := add_job(format('PARTMAN SETUP PARENT: %s', p_parent_table));
+    v_step_id := add_step(v_job_id, format('Creating initial partitions on new parent table: %s', p_parent_table));
+END IF;
+
+-- If this parent table has siblings that are also partitioned (subpartitions), ensure this parent gets added to part_config_sub table so future maintenance will subpartition it
+-- Just doing in a loop to avoid having to assign a bunch of variables (should only run once, if at all; constraint should enforce only one value.)
+FOR v_row IN
+    WITH parent_table AS (
+        SELECT h.inhparent AS parent_oid
+        FROM pg_catalog.pg_inherits h
+        JOIN pg_catalog.pg_class c ON h.inhrelid = c.oid
+        JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
+        WHERE c.relname = v_parent_tablename::name
+        AND n.nspname = v_parent_schemaname::name
+    ), sibling_children AS (
+        SELECT i.inhrelid::regclass::text AS tablename
+        FROM pg_inherits i
+        JOIN parent_table p ON i.inhparent = p.parent_oid
+    )
+    -- This column list must be kept consistent between:
+    --   , check_subpart_sameconfig, create_partition_id, create_partition_time, dump_partitioned_table_definition and table definition
+    SELECT DISTINCT
+        a.sub_control
+        , a.sub_partition_interval
+        , a.sub_partition_type
+        , a.sub_premake
+        , a.sub_automatic_maintenance
+        , a.sub_template_table
+        , a.sub_retention
+        , a.sub_retention_schema
+        , a.sub_retention_keep_index
+        , a.sub_retention_keep_table
+        , a.sub_epoch
+        , a.sub_constraint_cols
+        , a.sub_optimize_constraint
+        , a.sub_infinite_time_partitions
+        , a.sub_jobmon
+        , a.sub_inherit_privileges
+        , a.sub_constraint_valid
+        , a.sub_date_trunc_interval
+        , a.sub_ignore_default_data
+        , a.sub_default_table
+        , a.sub_retention_keep_publication
+    FROM @extschema@.part_config_sub a
+    JOIN sibling_children b on a.sub_parent = b.tablename LIMIT 1
+LOOP
+    INSERT INTO @extschema@.part_config_sub (
+        sub_parent
+        , sub_partition_type
+        , sub_control
+        , sub_partition_interval
+        , sub_constraint_cols
+        , sub_premake
+        , sub_retention
+        , sub_retention_schema
+        , sub_retention_keep_table
+        , sub_retention_keep_index
+        , sub_automatic_maintenance
+        , sub_epoch
+        , sub_optimize_constraint
+        , sub_infinite_time_partitions
+        , sub_jobmon
+        , sub_template_table
+        , sub_inherit_privileges
+        , sub_constraint_valid
+        , sub_date_trunc_interval
+        , sub_ignore_default_data
+        , sub_retention_keep_publication)
+    VALUES (
+        p_parent_table
+        , v_row.sub_partition_type
+        , v_row.sub_control
+        , v_row.sub_partition_interval
+        , v_row.sub_constraint_cols
+        , v_row.sub_premake
+        , v_row.sub_retention
+        , v_row.sub_retention_schema
+        , v_row.sub_retention_keep_index
+        , v_row.sub_retention_keep_table
+        , v_row.sub_automatic_maintenance
+        , v_row.sub_epoch
+        , v_row.sub_optimize_constraint
+        , v_row.sub_infinite_time_partitions
+        , v_row.sub_jobmon
+        , v_row.sub_template_table
+        , v_row.sub_inherit_privileges
+        , v_row.sub_constraint_valid
+        , v_row.sub_date_trunc_interval
+        , v_row.sub_ignore_default_data
+        , v_row.sub_retention_keep_publication);
+
+    -- Set this equal to sibling configs so that newly created child table
+    -- privileges are set properly below during initial setup.
+    -- This setting is special because it applies immediately to the new child
+    -- tables of a given parent, not just during maintenance like most other settings.
+    v_inherit_privileges = v_row.sub_inherit_privileges;
+END LOOP;
+
+IF v_control_type IN ('time', 'text', 'uuid') OR (v_control_type = 'id' AND p_epoch <> 'none') THEN
+
+    v_time_interval := p_interval::interval;
+    IF v_time_interval < '1 second'::interval THEN
+        RAISE EXCEPTION 'Partitioning interval must be 1 second or greater';
+    END IF;
+
+    -- Capture the timezone the set is aligned to (defaults to the creating
+    -- session's timezone). Stored in part_config so run_maintenance() keeps
+    -- future boundaries aligned regardless of the session it runs in.
+    v_partition_timezone := COALESCE(p_timezone, current_setting('TimeZone'));
+
+   -- First partition is either the min premake or p_start_partition
+    v_start_time := COALESCE(p_start_partition::timestamptz, CURRENT_TIMESTAMP - (v_time_interval * p_premake));
+
+    SELECT base_timestamp, datetime_string
+    INTO v_base_timestamp, v_datetime_string
+    FROM @extschema@.calculate_time_partition_info(v_time_interval, v_start_time, p_date_trunc_interval, v_partition_timezone);
+
+    RAISE DEBUG '(): parent_table: %, v_base_timestamp: %', p_parent_table, v_base_timestamp;
+
+    v_partition_time_array := array_append(v_partition_time_array, v_base_timestamp);
+
+    LOOP
+        -- If current loop value is less than or equal to the value of the max premake, add time to array.
+        IF (v_base_timestamp + (v_time_interval * v_count)) < (CURRENT_TIMESTAMP + (v_time_interval * p_premake)) THEN
+            BEGIN
+                v_partition_time := (v_base_timestamp + (v_time_interval * v_count))::timestamptz;
+                v_partition_time_array := array_append(v_partition_time_array, v_partition_time);
+            EXCEPTION WHEN datetime_field_overflow THEN
+                RAISE WARNING 'Attempted partition time interval is outside PostgreSQL''s supported time range.
+                    Child partition creation after time % skipped', v_partition_time;
+                v_step_overflow_id := add_step(v_job_id, 'Attempted partition time interval is outside PostgreSQL''s supported time range.');
+                PERFORM update_step(v_step_overflow_id, 'CRITICAL', 'Child partition creation after time '||v_partition_time||' skipped');
+                CONTINUE;
+            END;
+        ELSE
+            EXIT; -- all needed partitions added to array. Exit the loop.
+        END IF;
+        v_count := v_count + 1;
+    END LOOP;
+
+    INSERT INTO @extschema@.part_config (
+        parent_table
+        , partition_type
+        , partition_interval
+        , epoch
+        , control
+        , premake
+        , time_encoder
+        , time_decoder
+        , constraint_cols
+        , datetime_string
+        , automatic_maintenance
+        , jobmon
+        , template_table
+        , inherit_privileges
+        , date_trunc_interval
+        , partition_timezone)
+    VALUES (
+        p_parent_table
+        , p_type
+        , v_time_interval
+        , p_epoch
+        , p_control
+        , p_premake
+        , p_time_encoder
+        , p_time_decoder
+        , p_constraint_cols
+        , v_datetime_string
+        , p_automatic_maintenance
+        , p_jobmon
+        , v_template_schema||'.'||v_template_tablename
+        , v_inherit_privileges
+        , p_date_trunc_interval
+        , v_partition_timezone);
+
+    RAISE DEBUG ': v_partition_time_array: %', v_partition_time_array;
+
+    v_last_partition_created := @extschema@.create_partition_time(p_parent_table, v_partition_time_array);
+
+    IF v_last_partition_created = false THEN
+        -- This can happen with subpartitioning when future or past partitions prevent child creation because they're out of range of the parent
+        -- First see if this parent is a subpartition managed by pg_partman
+        WITH top_oid AS (
+            SELECT i.inhparent AS top_parent_oid
+            FROM pg_catalog.pg_inherits i
+            JOIN pg_catalog.pg_class c ON c.oid = i.inhrelid
+            JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+            WHERE c.relname = v_parent_tablename::name
+            AND n.nspname = v_parent_schemaname::name
+        ) SELECT n.nspname, c.relname
+        INTO v_top_parent_schema, v_top_parent_table
+        FROM pg_catalog.pg_class c
+        JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+        JOIN top_oid t ON c.oid = t.top_parent_oid
+        JOIN @extschema@.part_config p ON p.parent_table = n.nspname||'.'||c.relname;
+
+        IF v_top_parent_table IS NOT NULL THEN
+            -- If so create the lowest possible partition that is within the boundary of the parent
+            SELECT child_start_time INTO v_parent_partition_timestamp FROM @extschema@.show_partition_info(p_parent_table, p_parent_table := v_top_parent_schema||'.'||v_top_parent_table);
+            IF v_base_timestamp >= v_parent_partition_timestamp THEN
+                WHILE v_base_timestamp >= v_parent_partition_timestamp LOOP
+                    v_base_timestamp := v_base_timestamp - v_time_interval;
+                END LOOP;
+                v_base_timestamp := v_base_timestamp + v_time_interval; -- add one back since while loop set it one lower than is needed
+            ELSIF v_base_timestamp < v_parent_partition_timestamp THEN
+                WHILE v_base_timestamp < v_parent_partition_timestamp LOOP
+                    v_base_timestamp := v_base_timestamp + v_time_interval;
+                END LOOP;
+                -- Don't need to remove one since new starting time will fit in top parent interval
+            END IF;
+            v_partition_time_array := NULL;
+            v_partition_time_array := array_append(v_partition_time_array, v_base_timestamp);
+            v_last_partition_created := @extschema@.create_partition_time(p_parent_table, v_partition_time_array);
+        ELSE
+            RAISE WARNING 'No child tables created. Check that all child tables did not already exist and may not have been part of partition set. Given parent has still been configured with pg_partman, but may not have expected children. Please review schema and config to confirm things are ok.';
+
+            IF v_jobmon_schema IS NOT NULL THEN
+                PERFORM update_step(v_step_id, 'OK', 'Done');
+                IF v_step_overflow_id IS NOT NULL THEN
+                    PERFORM fail_job(v_job_id);
+                ELSE
+                    PERFORM close_job(v_job_id);
+                END IF;
+            END IF;
+
+            RETURN v_success;
+        END IF;
+    END IF; -- End v_last_partition IF
+
+    IF v_jobmon_schema IS NOT NULL THEN
+        PERFORM update_step(v_step_id, 'OK', format('Time partitions premade: %s', p_premake));
+    END IF;
+
+END IF;
+
+IF v_control_type = 'id' AND p_epoch = 'none' THEN
+    v_id_interval := p_interval::bigint;
+    IF v_id_interval < 2 AND p_type != 'list' THEN
+       RAISE EXCEPTION 'Interval for range partitioning must be greater than or equal to 2. Use LIST partitioning for single value partitions. (Values given: p_interval: %, p_type: %)', p_interval, p_type;
+    END IF;
+
+    -- Check if parent table is a subpartition of an already existing id partition set managed by pg_partman.
+    WHILE v_higher_parent_table IS NOT NULL LOOP -- initially set in DECLARE
+        WITH top_oid AS (
+            SELECT i.inhparent AS top_parent_oid
+            FROM pg_catalog.pg_inherits i
+            JOIN pg_catalog.pg_class c ON c.oid = i.inhrelid
+            JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+            WHERE n.nspname = v_higher_parent_schema::name
+            AND c.relname = v_higher_parent_table::name
+        ) SELECT n.nspname, c.relname, p.control, p.epoch
+        INTO v_higher_parent_schema, v_higher_parent_table, v_higher_parent_control, v_higher_parent_epoch
+        FROM pg_catalog.pg_class c
+        JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+        JOIN top_oid t ON c.oid = t.top_parent_oid
+        JOIN @extschema@.part_config p ON p.parent_table = n.nspname||'.'||c.relname;
+
+        IF v_higher_parent_table IS NOT NULL THEN
+            SELECT general_type INTO v_higher_control_type
+            FROM @extschema@.check_control_type(v_higher_parent_schema, v_higher_parent_table, v_higher_parent_control);
+            IF v_higher_control_type <> 'id' or (v_higher_control_type = 'id' AND v_higher_parent_epoch <> 'none') THEN
+                -- The parent above the p_parent_table parameter is not partitioned by ID
+                --   so don't check for max values in parents that aren't partitioned by ID.
+                -- This avoids missing child tables in subpartition sets that have differing ID data
+                EXIT;
+            END IF;
+            -- v_top_parent initially set in DECLARE
+            v_top_parent_schema := v_higher_parent_schema;
+            v_top_parent_table := v_higher_parent_table;
+        END IF;
+    END LOOP;
+
+    -- If custom start partition is set, use that.
+    -- If custom start is not set and there is already data, start partitioning with the highest current value and ensure it's grabbed from highest top parent table
+    IF p_start_partition IS NOT NULL THEN
+        v_max := p_start_partition::bigint;
+    ELSE
+        v_sql := format('SELECT COALESCE(trunc(max(%I))::bigint, 0) FROM %I.%I LIMIT 1'
+                    , p_control
+                    , v_top_parent_schema
+                    , v_top_parent_table);
+        EXECUTE v_sql INTO v_max;
+    END IF;
+
+    v_starting_partition_id := ((v_max - (v_max % v_id_interval)) + p_offset_id);
+    FOR i IN 0..p_premake LOOP
+        -- Only make previous partitions if ID value is less than the starting value and positive (and custom start partition wasn't set)
+        IF p_start_partition IS NULL AND
+            (v_starting_partition_id - (v_id_interval*i)) > 0 AND
+            (v_starting_partition_id - (v_id_interval*i)) < v_starting_partition_id
+        THEN
+            v_partition_id_array = array_append(v_partition_id_array, (v_starting_partition_id - v_id_interval*i));
+        END IF;
+        v_partition_id_array = array_append(v_partition_id_array, (v_id_interval*i) + v_starting_partition_id);
+    END LOOP;
+
+    INSERT INTO @extschema@.part_config (
+        parent_table
+        , partition_type
+        , partition_interval
+        , control
+        , premake
+        , constraint_cols
+        , automatic_maintenance
+        , jobmon
+        , template_table
+        , inherit_privileges
+        , date_trunc_interval)
+    VALUES (
+        p_parent_table
+        , p_type
+        , v_id_interval
+        , p_control
+        , p_premake
+        , p_constraint_cols
+        , p_automatic_maintenance
+        , p_jobmon
+        , v_template_schema||'.'||v_template_tablename
+        , v_inherit_privileges
+        , p_date_trunc_interval);
+
+    v_last_partition_created := @extschema@.create_partition_id(p_parent_table, v_partition_id_array);
+
+    IF v_last_partition_created = false THEN
+        -- This can happen with subpartitioning when future or past partitions prevent child creation because they're out of range of the parent
+        -- See if it's actually a subpartition of a parent id partition
+        WITH top_oid AS (
+            SELECT i.inhparent AS top_parent_oid
+            FROM pg_catalog.pg_inherits i
+            JOIN pg_catalog.pg_class c ON c.oid = i.inhrelid
+            JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+            WHERE c.relname = v_parent_tablename::name
+            AND n.nspname = v_parent_schemaname::name
+        ) SELECT n.nspname||'.'||c.relname
+        INTO v_top_parent_table
+        FROM pg_catalog.pg_class c
+        JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+        JOIN top_oid t ON c.oid = t.top_parent_oid
+        JOIN @extschema@.part_config p ON p.parent_table = n.nspname||'.'||c.relname;
+
+        IF v_top_parent_table IS NOT NULL THEN
+            -- Create the lowest possible partition that is within the boundary of the parent
+             SELECT child_start_id INTO v_parent_partition_id FROM @extschema@.show_partition_info(p_parent_table, p_parent_table := v_top_parent_table);
+            IF v_starting_partition_id >= v_parent_partition_id THEN
+                WHILE v_starting_partition_id >= v_parent_partition_id LOOP
+                    v_starting_partition_id := v_starting_partition_id - v_id_interval;
+                END LOOP;
+                v_starting_partition_id := v_starting_partition_id + v_id_interval; -- add one back since while loop set it one lower than is needed
+            ELSIF v_starting_partition_id < v_parent_partition_id THEN
+                WHILE v_starting_partition_id < v_parent_partition_id LOOP
+                    v_starting_partition_id := v_starting_partition_id + v_id_interval;
+                END LOOP;
+                -- Don't need to remove one since new starting id will fit in top parent interval
+            END IF;
+            v_partition_id_array = NULL;
+            v_partition_id_array = array_append(v_partition_id_array, v_starting_partition_id);
+            v_last_partition_created := @extschema@.create_partition_id(p_parent_table, v_partition_id_array);
+        ELSE
+            -- Currently unknown edge case if code gets here
+            RAISE WARNING 'No child tables created. Check that all child tables did not already exist and may not have been part of partition set. Given parent has still been configured with pg_partman, but may not have expected children. Please review schema and config to confirm things are ok.';
+            IF v_jobmon_schema IS NOT NULL THEN
+                PERFORM update_step(v_step_id, 'OK', 'Done');
+                IF v_step_overflow_id IS NOT NULL THEN
+                    PERFORM fail_job(v_job_id);
+                ELSE
+                    PERFORM close_job(v_job_id);
+                END IF;
+            END IF;
+
+            RETURN v_success;
+        END IF;
+    END IF; -- End v_last_partition_created IF
+
+END IF; -- End IF id
+
+IF p_default_table THEN
+    -- Add default partition
+
+    v_default_partition := @extschema@.check_name_length(v_parent_tablename, '_default', FALSE);
+    v_sql := 'CREATE';
+
+    -- Same INCLUDING list is used in create_partition_*(). INDEXES is handled when partition is attached if it's supported.
+    v_sql := v_sql || format(' TABLE IF NOT EXISTS %I.%I (LIKE %I.%I INCLUDING COMMENTS INCLUDING COMPRESSION INCLUDING CONSTRAINTS INCLUDING DEFAULTS INCLUDING GENERATED INCLUDING STATISTICS INCLUDING STORAGE)'
+        , v_parent_schemaname, v_default_partition, v_parent_schemaname, v_parent_tablename);
+    IF v_parent_tablespace IS NOT NULL THEN
+        v_sql := format('%s TABLESPACE %I ', v_sql, v_parent_tablespace);
+    END IF;
+    EXECUTE v_sql;
+
+    v_sql := format('ALTER TABLE %I.%I ATTACH PARTITION %I.%I DEFAULT'
+        , v_parent_schemaname, v_parent_tablename, v_parent_schemaname, v_default_partition);
+    EXECUTE v_sql;
+
+    PERFORM @extschema@.inherit_replica_identity(v_parent_schemaname, v_parent_tablename, v_default_partition);
+
+    -- Manage template inherited properties
+    IF v_template_tablename IS NOT NULL THEN
+        PERFORM @extschema@.inherit_template_properties(p_parent_table, v_parent_schemaname, v_default_partition);
+    END IF;
+
+END IF;
+
+
+IF v_jobmon_schema IS NOT NULL THEN
+    PERFORM update_step(v_step_id, 'OK', 'Done');
+    IF v_step_overflow_id IS NOT NULL THEN
+        PERFORM fail_job(v_job_id);
+    ELSE
+        PERFORM close_job(v_job_id);
+    END IF;
+END IF;
+
+v_success := true;
+
+RETURN v_success;
+
+EXCEPTION
+    WHEN OTHERS THEN
+        GET STACKED DIAGNOSTICS ex_message = MESSAGE_TEXT,
+                                ex_context = PG_EXCEPTION_CONTEXT,
+                                ex_detail = PG_EXCEPTION_DETAIL,
+                                ex_hint = PG_EXCEPTION_HINT;
+        IF v_jobmon_schema IS NOT NULL THEN
+            IF v_job_id IS NULL THEN
+                EXECUTE format('SELECT %I.add_job(''PARTMAN CREATE PARENT: %s'')', v_jobmon_schema, p_parent_table) INTO v_job_id;
+                EXECUTE format('SELECT %I.add_step(%s, ''Partition creation for table '||p_parent_table||' failed'')', v_jobmon_schema, v_job_id, p_parent_table) INTO v_step_id;
+            ELSIF v_step_id IS NULL THEN
+                EXECUTE format('SELECT %I.add_step(%s, ''EXCEPTION before first step logged'')', v_jobmon_schema, v_job_id) INTO v_step_id;
+            END IF;
+            EXECUTE format('SELECT %I.update_step(%s, ''CRITICAL'', %L)', v_jobmon_schema, v_step_id, 'ERROR: '||coalesce(SQLERRM,'unknown'));
+            EXECUTE format('SELECT %I.fail_job(%s)', v_jobmon_schema, v_job_id);
+        END IF;
+        RAISE EXCEPTION '%
+CONTEXT: %
+DETAIL: %
+HINT: %', ex_message, ex_context, ex_detail, ex_hint;
+END
+$$;
+
+CREATE OR REPLACE FUNCTION @extschema@.create_parent(
+    p_parent_table text
+    , p_control text
+    , p_interval text
+    , p_type text DEFAULT 'range'
+    , p_epoch text DEFAULT 'none'
+    , p_premake int DEFAULT 4
+    , p_start_partition text DEFAULT NULL
+    , p_default_table boolean DEFAULT true
+    , p_automatic_maintenance text DEFAULT 'on'
+    , p_constraint_cols text[] DEFAULT NULL
+    , p_template_table text DEFAULT NULL
+    , p_jobmon boolean DEFAULT true
+    , p_date_trunc_interval text DEFAULT NULL
+    , p_control_not_null boolean DEFAULT true
+    , p_time_encoder text DEFAULT NULL
+    , p_time_decoder text DEFAULT NULL
+    , p_offset_id bigint DEFAULT 0
+    , p_timezone text DEFAULT NULL
+)
+    RETURNS boolean
+    LANGUAGE plpgsql
+    SET search_path = @extschema@, pg_catalog, pg_temp
+    AS $$
+DECLARE
+
+BEGIN
+/*
+    This is an alias function for create_partition() for backward compatibility
+*/
+
+RETURN @extschema@.create_partition(
+    p_parent_table
+    , p_control
+    , p_interval
+    , p_type
+    , p_epoch
+    , p_premake
+    , p_start_partition
+    , p_default_table
+    , p_automatic_maintenance
+    , p_constraint_cols
+    , p_template_table
+    , p_jobmon
+    , p_date_trunc_interval
+    , p_control_not_null
+    , p_time_encoder
+    , p_time_decoder
+    , p_offset_id
+    , p_timezone
+);
+
+END
+$$;
+
+CREATE OR REPLACE FUNCTION @extschema@.create_partition_time(
+    p_parent_table text
+    , p_partition_times timestamptz[]
+    , p_start_partition text DEFAULT NULL
+)
+    RETURNS boolean
+    LANGUAGE plpgsql
+    SET search_path = @extschema@, pg_catalog, pg_temp
+    AS $$
+DECLARE
+
+ex_context                      text;
+ex_detail                       text;
+ex_hint                         text;
+ex_message                      text;
+v_control                       text;
+v_control_type                  text;
+v_time_encoder                  text;
+v_datetime_string               text;
+v_epoch                         text;
+v_exists                        smallint;
+v_inherit_privileges            boolean;
+v_job_id                        bigint;
+v_jobmon                        boolean;
+v_jobmon_schema                 text;
+v_new_search_path               text;
+v_old_search_path               text;
+v_parent_oid                    oid;
+v_parent_schema                 text;
+v_parent_tablename              text;
+v_parent_tablespace             name;
+v_partition_created             boolean := false;
+v_partition_name                text;
+v_partition_suffix              text;
+v_partition_expression          text;
+v_partition_interval            interval;
+v_partition_timestamp_end       timestamptz;
+v_partition_timestamp_start     timestamptz;
+v_row                           record;
+v_sql                           text;
+v_step_id                       bigint;
+v_step_overflow_id              bigint;
+v_sub_control                   text;
+v_sub_partition_type            text;
+v_sub_timestamp_max             timestamptz;
+v_sub_timestamp_min             timestamptz;
+v_template_table                text;
+v_time                          timestamptz;
+v_partition_text_start          text;
+v_partition_text_end            text;
+v_partition_timezone            text;
+v_timezone                      text;
+
+BEGIN
+/*
+ * Function to create a child table in a time-based partition set
+ */
+
+SELECT control
+    , time_encoder
+    , partition_interval::interval -- this shared field also used in partition_id as bigint
+    , epoch
+    , jobmon
+    , datetime_string
+    , template_table
+    , inherit_privileges
+    , partition_timezone
+INTO v_control
+    , v_time_encoder
+    , v_partition_interval
+    , v_epoch
+    , v_jobmon
+    , v_datetime_string
+    , v_template_table
+    , v_inherit_privileges
+    , v_partition_timezone
+FROM @extschema@.part_config
+WHERE parent_table = p_parent_table;
+
+IF NOT FOUND THEN
+    RAISE EXCEPTION 'ERROR: no config found for %', p_parent_table;
+END IF;
+
+-- Boundary end and child name suffix are computed in the set's own timezone so
+-- they stay aligned regardless of the session timezone. NULL falls back to the
+-- session timezone, preserving historical behavior.
+v_timezone := COALESCE(v_partition_timezone, current_setting('TimeZone'));
+
+SELECT n.nspname
+    , c.relname
+    , c.oid
+    , t.spcname
+INTO v_parent_schema
+    , v_parent_tablename
+    , v_parent_oid
+    , v_parent_tablespace
+FROM pg_catalog.pg_class c
+JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
+LEFT OUTER JOIN pg_catalog.pg_tablespace t ON c.reltablespace = t.oid
+WHERE n.nspname = split_part(p_parent_table, '.', 1)::name
+AND c.relname = split_part(p_parent_table, '.', 2)::name;
+
+SELECT general_type INTO v_control_type FROM @extschema@.check_control_type(v_parent_schema, v_parent_tablename, v_control);
+IF v_control_type <> 'time' THEN
+    IF (v_control_type = 'id' AND v_epoch = 'none') OR v_control_type NOT IN ('text', 'id', 'uuid') OR (v_control_type IN ('text', 'uuid') AND v_time_encoder IS NULL) THEN
+        RAISE EXCEPTION 'Cannot run on partition set without time based control column, an epoch flag set with an id column or time_encoder set with text column. Found control: %, epoch: %, time_encoder: %s', v_control_type, v_epoch, v_time_encoder;
+    END IF;
+END IF;
+
+IF v_jobmon THEN
+    SELECT nspname INTO v_jobmon_schema FROM pg_catalog.pg_namespace n, pg_catalog.pg_extension e WHERE e.extname = 'pg_jobmon'::name AND e.extnamespace = n.oid;
+    IF v_jobmon_schema IS NOT NULL THEN
+        SELECT current_setting('search_path') INTO v_old_search_path;
+        IF v_jobmon_schema IS NOT NULL THEN
+            v_new_search_path := format('%s,%s',v_jobmon_schema, v_old_search_path);
+            EXECUTE format('SET LOCAL search_path TO %s', v_new_search_path);
+        END IF;
+    END IF;
+END IF;
+
+-- Determine if this table is a child of a subpartition parent. If so, get limits of what child tables can be created based on parent suffix
+SELECT sub_min::timestamptz, sub_max::timestamptz INTO v_sub_timestamp_min, v_sub_timestamp_max FROM @extschema@.check_subpartition_limits(p_parent_table, 'time');
+
+IF v_jobmon_schema IS NOT NULL THEN
+    v_job_id := add_job(format('PARTMAN CREATE TABLE: %s', p_parent_table));
+END IF;
+
+v_partition_expression := CASE
+    WHEN v_epoch = 'seconds' THEN format('to_timestamp(%I)', v_control)
+    WHEN v_epoch = 'milliseconds' THEN format('to_timestamp((%I/1000)::float)', v_control)
+    WHEN v_epoch = 'microseconds' THEN format('to_timestamp((%I/1000000)::float)', v_control)
+    WHEN v_epoch = 'nanoseconds' THEN format('to_timestamp((%I/1000000000)::float)', v_control)
+    ELSE format('%I', v_control)
+END;
+RAISE DEBUG 'create_partition_time: v_partition_expression: %', v_partition_expression;
+
+FOREACH v_time IN ARRAY p_partition_times LOOP
+    v_partition_timestamp_start := v_time;
+    BEGIN
+        v_partition_timestamp_end := (v_time AT TIME ZONE v_timezone + v_partition_interval) AT TIME ZONE v_timezone;
+    EXCEPTION WHEN datetime_field_overflow THEN
+        RAISE WARNING 'Attempted partition time interval is outside PostgreSQL''s supported time range.
+            Child partition creation after time % skipped', v_time;
+        v_step_overflow_id := add_step(v_job_id, 'Attempted partition time interval is outside PostgreSQL''s supported time range.');
+        PERFORM update_step(v_step_overflow_id, 'CRITICAL', 'Child partition creation after time '||v_time||' skipped');
+
+        CONTINUE;
+    END;
+
+    -- Do not create the child table if it's outside the bounds of the top parent.
+    IF v_sub_timestamp_min IS NOT NULL THEN
+        IF v_time < v_sub_timestamp_min OR v_time >= v_sub_timestamp_max THEN
+
+            RAISE DEBUG 'create_partition_time: p_parent_table: %, v_time: %, v_sub_timestamp_min: %, v_sub_timestamp_max: %'
+                    , p_parent_table, v_time, v_sub_timestamp_min, v_sub_timestamp_max;
+
+            CONTINUE;
+        END IF;
+    END IF;
+
+    -- This suffix generation code is in partition_data_time() as well
+    v_partition_suffix := to_char(v_time AT TIME ZONE v_timezone, v_datetime_string);
+    v_partition_name := @extschema@.check_name_length(v_parent_tablename, v_partition_suffix, TRUE);
+    -- Check if child exists.
+    SELECT count(*) INTO v_exists
+    FROM pg_catalog.pg_class c
+    JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
+    WHERE n.nspname = v_parent_schema::name
+    AND c.relname = v_partition_name::name;
+
+    IF v_exists > 0 THEN
+        CONTINUE;
+    END IF;
+
+    IF v_jobmon_schema IS NOT NULL THEN
+        v_step_id := add_step(v_job_id, format('Creating new partition %s.%s with interval from %s to %s'
+                                                , v_parent_schema
+                                                , v_partition_name
+                                                , v_partition_timestamp_start
+                                                , v_partition_timestamp_end-'1sec'::interval));
+    END IF;
+
+    v_sql := 'CREATE';
+
+
+    -- Same INCLUDING list is used in create_partition()
+    v_sql := v_sql || format(' TABLE %I.%I (LIKE %I.%I INCLUDING COMMENTS INCLUDING COMPRESSION INCLUDING CONSTRAINTS INCLUDING DEFAULTS INCLUDING GENERATED INCLUDING STATISTICS INCLUDING STORAGE) '
+                                , v_parent_schema
+                                , v_partition_name
+                                , v_parent_schema
+                                , v_parent_tablename);
+
+    IF v_parent_tablespace IS NOT NULL THEN
+        v_sql := format('%s TABLESPACE %I ', v_sql, v_parent_tablespace);
+    END IF;
+
+    SELECT sub_partition_type, sub_control INTO v_sub_partition_type, v_sub_control
+    FROM @extschema@.part_config_sub
+    WHERE sub_parent = p_parent_table;
+    IF v_sub_partition_type = 'range' THEN
+        v_sql :=  format('%s PARTITION BY RANGE (%I) ', v_sql, v_sub_control);
+    END IF;
+
+    RAISE DEBUG 'create_partition_time v_sql: %', v_sql;
+    EXECUTE v_sql;
+
+    IF v_template_table IS NOT NULL THEN
+        PERFORM @extschema@.inherit_template_properties(p_parent_table, v_parent_schema, v_partition_name);
+    END IF;
+
+    IF v_epoch = 'none' THEN
+        -- Attach with normal, time-based values for built-in constraint
+        IF v_time_encoder IS NULL THEN
+            EXECUTE format('ALTER TABLE %I.%I ATTACH PARTITION %I.%I FOR VALUES FROM (%L) TO (%L)'
+                , v_parent_schema
+                , v_parent_tablename
+                , v_parent_schema
+                , v_partition_name
+                , v_partition_timestamp_start
+                , v_partition_timestamp_end);
+        ELSE
+            EXECUTE format('SELECT %s(%L)', v_time_encoder, v_partition_timestamp_start) INTO v_partition_text_start;
+            EXECUTE format('SELECT %s(%L)', v_time_encoder, v_partition_timestamp_end) INTO v_partition_text_end;
+
+            EXECUTE format('ALTER TABLE %I.%I ATTACH PARTITION %I.%I FOR VALUES FROM (%L) TO (%L)'
+                , v_parent_schema
+                , v_parent_tablename
+                , v_parent_schema
+                , v_partition_name
+                , v_partition_text_start
+                , v_partition_text_end);
+        END IF;
+
+    ELSE
+        -- Must attach with integer based values for built-in constraint and epoch
+        IF v_epoch = 'seconds' THEN
+            EXECUTE format('ALTER TABLE %I.%I ATTACH PARTITION %I.%I FOR VALUES FROM (%L) TO (%L)'
+                , v_parent_schema
+                , v_parent_tablename
+                , v_parent_schema
+                , v_partition_name
+                , EXTRACT('epoch' FROM v_partition_timestamp_start)::bigint
+                , EXTRACT('epoch' FROM v_partition_timestamp_end)::bigint);
+        ELSIF v_epoch = 'milliseconds' THEN
+            EXECUTE format('ALTER TABLE %I.%I ATTACH PARTITION %I.%I FOR VALUES FROM (%L) TO (%L)'
+                , v_parent_schema
+                , v_parent_tablename
+                , v_parent_schema
+                , v_partition_name
+                , EXTRACT('epoch' FROM v_partition_timestamp_start)::bigint * 1000
+                , EXTRACT('epoch' FROM v_partition_timestamp_end)::bigint * 1000);
+        ELSIF v_epoch = 'microseconds' THEN
+            EXECUTE format('ALTER TABLE %I.%I ATTACH PARTITION %I.%I FOR VALUES FROM (%L) TO (%L)'
+                , v_parent_schema
+                , v_parent_tablename
+                , v_parent_schema
+                , v_partition_name
+                , EXTRACT('epoch' FROM v_partition_timestamp_start)::bigint * 1000000
+                , EXTRACT('epoch' FROM v_partition_timestamp_end)::bigint * 1000000);
+        ELSIF v_epoch = 'nanoseconds' THEN
+            EXECUTE format('ALTER TABLE %I.%I ATTACH PARTITION %I.%I FOR VALUES FROM (%L) TO (%L)'
+                , v_parent_schema
+                , v_parent_tablename
+                , v_parent_schema
+                , v_partition_name
+                , EXTRACT('epoch' FROM v_partition_timestamp_start)::bigint * 1000000000
+                , EXTRACT('epoch' FROM v_partition_timestamp_end)::bigint * 1000000000);
+        END IF;
+        -- Create secondary, time-based constraint since built-in's constraint is already integer based
+        EXECUTE format('ALTER TABLE %I.%I ADD CONSTRAINT %I CHECK (%s >= %L AND %4$s < %6$L)'
+            , v_parent_schema
+            , v_partition_name
+            , v_partition_name||'_partition_check'
+            , v_partition_expression
+            , v_partition_timestamp_start
+            , v_partition_timestamp_end);
+    END IF;
+
+    -- NOTE: Privileges not automatically inherited. Only do so if config flag is set
+    IF v_inherit_privileges = TRUE THEN
+        PERFORM @extschema@.apply_privileges(v_parent_schema, v_parent_tablename, v_parent_schema, v_partition_name, v_job_id);
+    END IF;
+
+    IF v_jobmon_schema IS NOT NULL THEN
+        PERFORM update_step(v_step_id, 'OK', 'Done');
+    END IF;
+
+    -- Will only loop once and only if sub_partitioning is actually configured
+    -- This seemed easier than assigning a bunch of variables and doing an IF condition
+    -- This column list must be kept consistent between:
+    --   create_partition, check_subpart_sameconfig, create_partition_id, create_partition_time, dump_partitioned_table_definition, and table definition
+    FOR v_row IN
+        SELECT
+            sub_parent
+            , sub_control
+            , sub_time_encoder
+            , sub_time_decoder
+            , sub_partition_interval
+            , sub_partition_type
+            , sub_premake
+            , sub_automatic_maintenance
+            , sub_template_table
+            , sub_retention
+            , sub_retention_schema
+            , sub_retention_keep_index
+            , sub_retention_keep_table
+            , sub_epoch
+            , sub_constraint_cols
+            , sub_optimize_constraint
+            , sub_infinite_time_partitions
+            , sub_jobmon
+            , sub_inherit_privileges
+            , sub_constraint_valid
+            , sub_date_trunc_interval
+            , sub_ignore_default_data
+            , sub_default_table
+            , sub_maintenance_order
+            , sub_retention_keep_publication
+            , sub_control_not_null
+        FROM @extschema@.part_config_sub
+        WHERE sub_parent = p_parent_table
+    LOOP
+        IF v_jobmon_schema IS NOT NULL THEN
+            v_step_id := add_step(v_job_id, format('Subpartitioning %s.%s', v_parent_schema, v_partition_name));
+        END IF;
+        v_sql := format('SELECT @extschema@.create_partition(
+                 p_parent_table := %L
+                , p_control := %L
+                , p_time_encoder := %L
+                , p_time_decoder := %L
+                , p_interval := %L
+                , p_type := %L
+                , p_default_table := %L
+                , p_constraint_cols := %L
+                , p_premake := %L
+                , p_automatic_maintenance := %L
+                , p_epoch := %L
+                , p_template_table := %L
+                , p_jobmon := %L
+                , p_start_partition := %L
+                , p_date_trunc_interval := %L
+                , p_control_not_null := %L )'
+            , v_parent_schema||'.'||v_partition_name
+            , v_row.sub_control
+            , v_row.sub_time_encoder
+            , v_row.sub_time_decoder
+            , v_row.sub_partition_interval
+            , v_row.sub_partition_type
+            , v_row.sub_default_table
+            , v_row.sub_constraint_cols
+            , v_row.sub_premake
+            , v_row.sub_automatic_maintenance
+            , v_row.sub_epoch
+            , v_row.sub_template_table
+            , v_row.sub_jobmon
+            , p_start_partition
+            , v_row.sub_date_trunc_interval
+            , v_row.sub_control_not_null);
+
+        RAISE DEBUG 'create_partition_time (create_partition loop): %', v_sql;
+        EXECUTE v_sql;
+
+        UPDATE @extschema@.part_config SET
+            retention_schema = v_row.sub_retention_schema
+            , retention_keep_table = v_row.sub_retention_keep_table
+            , optimize_constraint = v_row.sub_optimize_constraint
+            , infinite_time_partitions = v_row.sub_infinite_time_partitions
+            , inherit_privileges = v_row.sub_inherit_privileges
+            , constraint_valid = v_row.sub_constraint_valid
+            , ignore_default_data = v_row.sub_ignore_default_data
+            , maintenance_order = v_row.sub_maintenance_order
+            , retention_keep_publication = v_row.sub_retention_keep_publication
+        WHERE parent_table = v_parent_schema||'.'||v_partition_name;
+
+    END LOOP; -- end sub partitioning LOOP
+
+    -- NOTE: Replication identity not automatically inherited as of PG16 (revisit in future versions)
+    PERFORM @extschema@.inherit_replica_identity(v_parent_schema, v_parent_tablename, v_partition_name);
+
+    -- Manage additional constraints if set
+    PERFORM @extschema@.apply_constraints(p_parent_table, p_job_id := v_job_id);
+
+    v_partition_created := true;
+
+END LOOP;
+
+IF v_jobmon_schema IS NOT NULL THEN
+    IF v_partition_created = false THEN
+        v_step_id := add_step(v_job_id, format('No partitions created for partition set: %s. Attempted intervals: %s', p_parent_table, p_partition_times));
+        PERFORM update_step(v_step_id, 'OK', 'Done');
+    END IF;
+
+    IF v_step_overflow_id IS NOT NULL THEN
+        PERFORM fail_job(v_job_id);
+    ELSE
+        PERFORM close_job(v_job_id);
+    END IF;
+END IF;
+
+RETURN v_partition_created;
+
+EXCEPTION
+    WHEN OTHERS THEN
+        GET STACKED DIAGNOSTICS ex_message = MESSAGE_TEXT,
+                                ex_context = PG_EXCEPTION_CONTEXT,
+                                ex_detail = PG_EXCEPTION_DETAIL,
+                                ex_hint = PG_EXCEPTION_HINT;
+        IF v_jobmon_schema IS NOT NULL THEN
+            IF v_job_id IS NULL THEN
+                EXECUTE format('SELECT %I.add_job(''PARTMAN CREATE TABLE: %s'')', v_jobmon_schema, p_parent_table) INTO v_job_id;
+                EXECUTE format('SELECT %I.add_step(%s, ''EXCEPTION before job logging started'')', v_jobmon_schema, v_job_id, p_parent_table) INTO v_step_id;
+            ELSIF v_step_id IS NULL THEN
+                EXECUTE format('SELECT %I.add_step(%s, ''EXCEPTION before first step logged'')', v_jobmon_schema, v_job_id) INTO v_step_id;
+            END IF;
+            EXECUTE format('SELECT %I.update_step(%s, ''CRITICAL'', %L)', v_jobmon_schema, v_step_id, 'ERROR: '||coalesce(SQLERRM,'unknown'));
+            EXECUTE format('SELECT %I.fail_job(%s)', v_jobmon_schema, v_job_id);
+        END IF;
+        RAISE EXCEPTION '%
+CONTEXT: %
+DETAIL: %
+HINT: %', ex_message, ex_context, ex_detail, ex_hint;
+END
+$$;
+
+CREATE OR REPLACE FUNCTION @extschema@.run_maintenance(
+    p_parent_table text DEFAULT NULL
+    -- If these defaults change reflect them in `run_maintenance_proc`!
+    , p_analyze boolean DEFAULT false
+    , p_jobmon boolean DEFAULT true
+)
+    RETURNS void
+    LANGUAGE plpgsql
+    SET search_path = @extschema@, pg_catalog, pg_temp
+    AS $$
+DECLARE
+
+ex_context                      text;
+ex_detail                       text;
+ex_hint                         text;
+ex_message                      text;
+v_adv_lock                      boolean;
+v_analyze                       boolean := FALSE;
+v_check_subpart                 int;
+v_child_timestamp               timestamptz;
+v_control_type                  text;
+v_time_encoder                  text;
+v_time_decoder                  text;
+v_create_count                  int := 0;
+v_current_partition_id          bigint;
+v_current_partition_timestamp   timestamptz;
+v_default_tablename             text;
+v_default_version               text;
+v_drop_count                    int := 0;
+v_exact_control_type            text;
+v_installed_version             text;
+v_is_default                    text;
+v_job_id                        bigint;
+v_jobmon_schema                 text;
+v_last_partition                text;
+v_last_partition_created        boolean;
+v_last_partition_id             bigint;
+v_last_partition_timestamp      timestamptz;
+v_library_version               text;
+v_max_id                        bigint;
+v_max_id_default                bigint;
+v_max_time_default              timestamptz;
+v_new_search_path               text;
+v_next_partition_id             bigint;
+v_next_partition_timestamp      timestamptz;
+v_old_search_path               text;
+v_parent_exists                 text;
+v_parent_oid                    oid;
+v_parent_schema                 text;
+v_parent_tablename              text;
+v_partition_expression          text;
+v_premade_count                 int;
+v_row                           record;
+v_row_max_id                    record;
+v_row_max_time                  record;
+v_sql                           text;
+v_step_id                       bigint;
+v_step_overflow_id              bigint;
+v_sub_id_max                    bigint;
+v_sub_id_max_suffix             bigint;
+v_sub_id_min                    bigint;
+v_sub_parent                    text;
+v_sub_timestamp_max             timestamptz;
+v_sub_timestamp_max_suffix      timestamptz;
+v_sub_timestamp_min             timestamptz;
+v_tables_list_sql               text;
+v_timezone                      text;
+
+BEGIN
+/*
+ * Function to manage pre-creation of the next partitions in a set.
+ * Also manages dropping old partitions if the retention option is set.
+ * If p_parent_table is passed, will only run run_maintenance() on that one table (no matter what the configuration table may have set for it)
+ * Otherwise, will run on all tables in the config table with p_automatic_maintenance() set to true.
+ * For large partition sets, running analyze can cause maintenance to take longer than expected so is not done by default. Can set p_analyze to true to force analyze. Be aware that constraint exclusion may not work properly until an analyze on the partition set is run.
+ */
+
+v_adv_lock := pg_try_advisory_xact_lock(hashtext('pg_partman run_maintenance'));
+IF v_adv_lock = 'false' THEN
+    RAISE NOTICE 'Partman maintenance already running.';
+    RETURN;
+END IF;
+
+IF pg_is_in_recovery() THEN
+    RAISE DEBUG 'pg_partmain maintenance called on replica. Doing nothing.';
+    RETURN;
+END IF;
+
+IF p_jobmon THEN
+    SELECT nspname INTO v_jobmon_schema FROM pg_catalog.pg_namespace n, pg_catalog.pg_extension e WHERE e.extname = 'pg_jobmon'::name AND e.extnamespace = n.oid;
+    IF v_jobmon_schema IS NOT NULL THEN
+        SELECT current_setting('search_path') INTO v_old_search_path;
+        IF v_jobmon_schema IS NOT NULL THEN
+            v_new_search_path := format('%s,%s',v_jobmon_schema, v_old_search_path);
+            EXECUTE format('SET LOCAL search_path TO %s', v_new_search_path);
+        END IF;
+    END IF;
+END IF;
+
+IF current_setting('server_version_num')::int >= 180000 THEN
+    SELECT extversion INTO v_installed_version FROM pg_catalog.pg_extension WHERE extname = 'pg_partman';
+    SELECT version INTO v_library_version FROM pg_catalog.pg_get_loaded_modules() WHERE module_name = 'pg_partman';
+
+    IF replace(v_installed_version, '.', '')::int < replace(v_library_version, '.', '')::int THEN
+        RAISE EXCEPTION 'The installed version of pg_partman (%) is less than the shared library version file that has been loaded (%). Please ensure the expected version of pg_partman is installed to the system, update the extension if needed and restart the PostgreSQL instance.', v_installed_version, v_library_version;
+    END IF;
+END IF;
+
+-- Try and catch the same situation of a new library file existing on disk but the extension version not being updated properly in the database. Not as reliable as new feature in PG18, but better than nothing. Only do a warning since this is less definitely a problem than a known library mismatch.
+SELECT default_version, installed_version INTO v_default_version, v_installed_version FROM pg_available_extensions WHERE name = 'pg_partman' AND default_version != installed_version;
+IF v_installed_version IS NOT NULL THEN
+    RAISE WARNING 'pg_partman version % is installed in the database but version % is the default available. Please ensure the expected version of pg_partman is installed to the system, update the extension in all relevant databases and restart the PostgreSQL instance if a new shared library module is available. See release notes for further details.', v_installed_version, v_default_version;
+END IF;
+
+IF v_jobmon_schema IS NOT NULL THEN
+    v_job_id := add_job('PARTMAN RUN MAINTENANCE');
+    v_step_id := add_step(v_job_id, 'Running maintenance loop');
+END IF;
+
+v_tables_list_sql := 'SELECT parent_table
+                , partition_type
+                , partition_interval
+                , control
+                , premake
+                , undo_in_progress
+                , sub_partition_set_full
+                , epoch
+                , infinite_time_partitions
+                , retention
+                , ignore_default_data
+                , datetime_string
+                , maintenance_order
+                , date_trunc_interval
+                , async_partitioning_in_progress
+                , partition_timezone
+            FROM @extschema@.part_config
+            WHERE undo_in_progress = false';
+
+IF p_parent_table IS NULL THEN
+    v_tables_list_sql := v_tables_list_sql || format(' AND automatic_maintenance = %L ', 'on');
+ELSE
+    v_tables_list_sql := v_tables_list_sql || format(' AND parent_table = %L ', p_parent_table);
+END IF;
+
+v_tables_list_sql := v_tables_list_sql || format(' ORDER BY maintenance_order ASC NULLS LAST, parent_table ASC NULLS LAST ');
+
+RAISE DEBUG 'run_maint: v_tables_list_sql: %', v_tables_list_sql;
+
+FOR v_row IN EXECUTE v_tables_list_sql
+LOOP
+
+    CONTINUE WHEN v_row.undo_in_progress;
+
+    IF v_row.async_partitioning_in_progress IS NOT NULL THEN
+        RAISE WARNING 'Async partitioning in progress for partition set: %. Maintenance is being skipped for this partition set while this is in progress and will resume when it is complete during the next maintenance run. If this is not expected, please check the value of "async_partitioning_in_progress" in the "part_config" table and investigate for any incomplete asynchronous partitioning job attempts for this partition set.', v_row.parent_table;
+        CONTINUE;
+    END IF;
+
+    -- When sub-partitioning, retention may drop tables that were already put into the query loop values.
+    -- Check if they still exist in part_config before continuing
+    v_parent_exists := NULL;
+    SELECT parent_table, time_encoder, time_decoder INTO v_parent_exists, v_time_encoder, v_time_decoder FROM @extschema@.part_config WHERE parent_table = v_row.parent_table;
+    IF v_parent_exists IS NULL THEN
+        RAISE DEBUG 'run_maint: Parent table possibly removed from part_config by retenion';
+    END IF;
+    CONTINUE WHEN v_parent_exists IS NULL;
+
+    -- Check for old quarterly and ISO weekly partitioning from prior to version 5.x. Error out to avoid breaking these partition sets
+    -- with new datetime_string formats
+    IF v_row.datetime_string IN ('YYYY"q"Q', 'IYYY"w"IW') THEN
+        RAISE EXCEPTION 'Quarterly and ISO weekly partitioning is no longer supported in pg_partman 5.0.0 and greater. Please see documentation for migrating away from these partitioning patterns. Partition set: %', v_row.parent_table;
+    END IF;
+
+    -- Check for consistent data in part_config_sub table. Was unable to get this working properly as either a constraint or trigger.
+    -- Would either delay raising an error until the next write (which I cannot predict) or disallow future edits to update a sub-partition set's configuration.
+    -- This way at least provides a consistent way to check that I know will run. If anyone can get a working constraint/trigger, please help!
+    SELECT sub_parent INTO v_sub_parent FROM @extschema@.part_config_sub WHERE sub_parent = v_row.parent_table;
+    IF v_sub_parent IS NOT NULL THEN
+        SELECT count(*) INTO v_check_subpart FROM @extschema@.check_subpart_sameconfig(v_row.parent_table);
+        IF v_check_subpart > 1 THEN
+            RAISE EXCEPTION 'Inconsistent data in part_config_sub table. Sub-partition tables that are themselves sub-partitions cannot have differing configuration values among their siblings.
+            Run this query: "SELECT * FROM @extschema@.check_subpart_sameconfig(''%'');" This should only return a single row or nothing.
+            If multiple rows are returned, the results are differing configurations in the part_config_sub table for children of the given parent.
+            Determine the child tables of the given parent and look up their entries based on the "part_config_sub.sub_parent" column.
+            Update the differing values to be consistent for your desired values.', v_row.parent_table;
+        END IF;
+    END IF;
+
+    SELECT n.nspname, c.relname, c.oid
+    INTO v_parent_schema, v_parent_tablename, v_parent_oid
+    FROM pg_catalog.pg_class c
+    JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
+    WHERE n.nspname = split_part(v_row.parent_table, '.', 1)::name
+    AND c.relname = split_part(v_row.parent_table, '.', 2)::name;
+
+    -- Always returns the default partition first if it exists
+    SELECT partition_tablename INTO v_default_tablename
+    FROM @extschema@.show_partitions(v_row.parent_table, p_include_default := true) LIMIT 1;
+
+    SELECT pg_get_expr(relpartbound, v_parent_oid) INTO v_is_default
+    FROM pg_catalog.pg_class c
+    JOIN pg_catalog.pg_namespace n on c.relnamespace = n.oid
+    WHERE n.nspname = v_parent_schema
+    AND c.relname = v_default_tablename;
+
+    IF v_is_default != 'DEFAULT' THEN
+        -- Parent table will never have data, but allows code below to "just work"
+        v_default_tablename := v_parent_tablename;
+    END IF;
+
+    SELECT general_type, exact_type
+    INTO v_control_type, v_exact_control_type
+    FROM @extschema@.check_control_type(v_parent_schema, v_parent_tablename, v_row.control);
+
+    v_partition_expression := CASE
+        WHEN v_row.epoch = 'seconds' THEN format('to_timestamp(%I)', v_row.control)
+        WHEN v_row.epoch = 'milliseconds' THEN format('to_timestamp((%I/1000)::float)', v_row.control)
+        WHEN v_row.epoch = 'microseconds' THEN format('to_timestamp((%I/1000000)::float)', v_row.control)
+        WHEN v_row.epoch = 'nanoseconds' THEN format('to_timestamp((%I/1000000000)::float)', v_row.control)
+        ELSE format('%I', v_row.control)
+    END;
+    RAISE DEBUG 'run_maint: v_partition_expression: %', v_partition_expression;
+
+    -- All timestamptz boundary math below is done in the partition set's own
+    -- timezone so boundaries stay aligned no matter which session timezone
+    -- maintenance is invoked from. A NULL partition_timezone falls back to the
+    -- session timezone, preserving the historical behavior.
+    v_timezone := COALESCE(v_row.partition_timezone, current_setting('TimeZone'));
+
+    SELECT partition_tablename INTO v_last_partition FROM @extschema@.show_partitions(v_row.parent_table, 'DESC') LIMIT 1;
+    RAISE DEBUG 'run_maint: parent_table: %, v_last_partition: %', v_row.parent_table, v_last_partition;
+
+    IF v_control_type = 'time' OR (v_control_type = 'id' AND v_row.epoch <> 'none') OR (v_control_type IN ('text', 'uuid')) THEN
+
+        IF v_row.sub_partition_set_full THEN
+            UPDATE @extschema@.part_config SET maintenance_last_run = clock_timestamp() WHERE parent_table = v_row.parent_table;
+            CONTINUE;
+        END IF;
+
+        SELECT child_start_time INTO v_last_partition_timestamp
+            FROM @extschema@.show_partition_info(v_parent_schema||'.'||v_last_partition, v_row.partition_interval, v_row.parent_table);
+
+        -- Do not create child tables if they would be dropped by retention anyway. Edge case where maintenance was missed for
+        --  an extended period of time
+        IF v_row.retention IS NOT NULL THEN
+            v_last_partition_timestamp := greatest(v_last_partition_timestamp, CURRENT_TIMESTAMP - v_row.retention::interval);
+            -- Need to properly truncate the interval and account for custom date truncation
+            SELECT base_timestamp
+            INTO v_last_partition_timestamp
+            FROM @extschema@.calculate_time_partition_info(v_row.partition_interval::interval, v_last_partition_timestamp, v_row.date_trunc_interval, v_timezone);
+        END IF;
+
+        -- Must be reset to null otherwise if the next partition set in the loop is empty, the previous partition set's value could be used
+        v_current_partition_timestamp := NULL;
+
+        -- Loop through child tables starting from highest to get a timestamp from the highest non-empty partition in the set
+        -- Avoids doing a scan on entire partition set and/or getting any values accidentally in default.
+        FOR v_row_max_time IN
+            SELECT partition_schemaname, partition_tablename FROM @extschema@.show_partitions(v_row.parent_table, 'DESC', false)
+        LOOP
+            IF v_control_type = 'time' OR (v_control_type = 'id' AND v_row.epoch <> 'none') THEN
+                EXECUTE format('SELECT %s::text FROM %I.%I LIMIT 1'
+                                    , v_partition_expression
+                                    , v_row_max_time.partition_schemaname
+                                    , v_row_max_time.partition_tablename
+                                ) INTO v_child_timestamp;
+            ELSIF v_control_type IN ('text', 'uuid') THEN
+                EXECUTE format('SELECT %s(%s::text) FROM %I.%I LIMIT 1'
+                                    , v_time_decoder
+                                    , v_partition_expression
+                                    , v_row_max_time.partition_schemaname
+                                    , v_row_max_time.partition_tablename
+                                ) INTO v_child_timestamp;
+            END IF;
+
+            IF v_row.infinite_time_partitions AND v_child_timestamp < CURRENT_TIMESTAMP THEN
+                -- No new data has been inserted relative to "now", but keep making child tables anyway
+                v_current_partition_timestamp = CURRENT_TIMESTAMP;
+                -- Nothing else to do in this case so just end early
+                EXIT;
+            END IF;
+            IF v_child_timestamp IS NOT NULL THEN
+                SELECT suffix_timestamp INTO v_current_partition_timestamp FROM @extschema@.show_partition_name(v_row.parent_table, v_child_timestamp::text);
+                EXIT;
+            END IF;
+        END LOOP;
+        IF v_row.infinite_time_partitions AND v_child_timestamp IS NULL THEN
+            -- If partition set is completely empty, still keep making child tables anyway
+            -- Has to be separate check outside above loop since "future" tables are likely going to be empty, hence ignored in that loop
+            v_current_partition_timestamp = CURRENT_TIMESTAMP;
+        END IF;
+
+        -- If not ignoring the default table, check for max values there. If they are there and greater than all child values, use that instead
+        -- Note the default is NOT to care about data in the default, so maintenance will fail if new child table boundaries overlap with
+        --  data that exists in the default. This is intentional so user removes data from default to avoid larger problems.
+        IF v_row.ignore_default_data THEN
+            v_max_time_default := NULL;
+        ELSE
+            EXECUTE format('SELECT max(%s) FROM ONLY %I.%I', v_partition_expression, v_parent_schema, v_default_tablename) INTO v_max_time_default;
+        END IF;
+        RAISE DEBUG 'run_maint: v_current_partition_timestamp: %, v_max_time_default: %', v_current_partition_timestamp, v_max_time_default;
+        IF v_current_partition_timestamp IS NULL AND v_max_time_default IS NULL THEN
+            -- Partition set is completely empty and infinite time partitions not set
+
+            -- Still need to run retention if needed. Note similar call below for non-empty sets. Keep in sync.
+            IF v_row.retention IS NOT NULL THEN
+                v_drop_count := v_drop_count + @extschema@.drop_partition_time(v_row.parent_table);
+            END IF;
+
+            -- Nothing else to do
+            UPDATE @extschema@.part_config SET maintenance_last_run = clock_timestamp() WHERE parent_table = v_row.parent_table;
+            CONTINUE;
+        END IF;
+        RAISE DEBUG 'run_maint: v_child_timestamp: %, v_current_partition_timestamp: %, v_max_time_default: %', v_child_timestamp, v_current_partition_timestamp, v_max_time_default;
+        IF v_current_partition_timestamp IS NULL OR (v_max_time_default > v_current_partition_timestamp) THEN
+            SELECT suffix_timestamp INTO v_current_partition_timestamp FROM @extschema@.show_partition_name(v_row.parent_table, v_max_time_default::text);
+        END IF;
+
+        -- If this is a subpartition, determine if the last child table has been made. If so, mark it as full so future maintenance runs can skip it
+        SELECT sub_min::timestamptz, sub_max::timestamptz INTO v_sub_timestamp_min, v_sub_timestamp_max FROM @extschema@.check_subpartition_limits(v_row.parent_table, 'time');
+        IF v_sub_timestamp_max IS NOT NULL THEN
+            SELECT suffix_timestamp INTO v_sub_timestamp_max_suffix FROM @extschema@.show_partition_name(v_row.parent_table, v_sub_timestamp_max::text);
+            IF v_sub_timestamp_max_suffix = v_last_partition_timestamp THEN
+                -- Final partition for this set is created. Set full and skip it
+                UPDATE @extschema@.part_config
+                SET sub_partition_set_full = true, maintenance_last_run = clock_timestamp()
+                WHERE parent_table = v_row.parent_table;
+                CONTINUE;
+            END IF;
+        END IF;
+
+        -- Check and see how many premade partitions there are.
+        v_premade_count = round(EXTRACT('epoch' FROM age(v_last_partition_timestamp, v_current_partition_timestamp)) / EXTRACT('epoch' FROM v_row.partition_interval::interval));
+        v_next_partition_timestamp := v_last_partition_timestamp;
+        RAISE DEBUG 'run_maint before loop: last_partition_timestamp: %, current_partition_timestamp: %, v_premade_count: %, v_sub_timestamp_min: %, v_sub_timestamp_max: %'
+            , v_last_partition_timestamp
+            , v_current_partition_timestamp
+            , v_premade_count
+            , v_sub_timestamp_min
+            , v_sub_timestamp_max;
+        -- Loop premaking until config setting is met. Allows it to catch up if it fell behind or if premake changed
+        WHILE (v_premade_count < v_row.premake) LOOP
+            RAISE DEBUG 'run_maint: parent_table: %, v_premade_count: %, v_next_partition_timestamp: %', v_row.parent_table, v_premade_count, v_next_partition_timestamp;
+            IF v_next_partition_timestamp < v_sub_timestamp_min OR v_next_partition_timestamp > v_sub_timestamp_max THEN
+                -- With subpartitioning, no need to run if the timestamp is not in the parent table's range
+                EXIT;
+            END IF;
+            BEGIN
+                -- Advance in the set's timezone so month/year intervals land on
+                -- the same wall-clock boundary (e.g. the 1st at 00:00) instead
+                -- of drifting when the session timezone differs from the set's.
+                v_next_partition_timestamp := (v_next_partition_timestamp AT TIME ZONE v_timezone + v_row.partition_interval::interval) AT TIME ZONE v_timezone;
+            EXCEPTION WHEN datetime_field_overflow THEN
+                v_premade_count := v_row.premake; -- do this so it can exit the premake check loop and continue in the outer for loop
+                IF v_jobmon_schema IS NOT NULL THEN
+                    v_step_overflow_id := add_step(v_job_id, 'Attempted partition time interval is outside PostgreSQL''s supported time range.');
+                    PERFORM update_step(v_step_overflow_id, 'CRITICAL', format('Child partition creation skipped for parent table: %s', v_partition_time));
+                END IF;
+                RAISE WARNING 'Attempted partition time interval is outside PostgreSQL''s supported time range. Child partition creation skipped for parent table %', v_row.parent_table;
+                CONTINUE;
+            END;
+
+            v_last_partition_created := @extschema@.create_partition_time(v_row.parent_table
+                                                        , ARRAY[v_next_partition_timestamp]);
+
+            IF v_last_partition_created THEN
+                v_analyze := true;
+                v_create_count := v_create_count + 1;
+            END IF;
+
+            v_premade_count = round(EXTRACT('epoch' FROM age(v_next_partition_timestamp, v_current_partition_timestamp)) / EXTRACT('epoch' FROM v_row.partition_interval::interval));
+        END LOOP;
+
+        -- Run retention if needed. Note similar call above when partition set is empty. Keep in sync.
+        IF v_row.retention IS NOT NULL THEN
+            v_drop_count := v_drop_count + @extschema@.drop_partition_time(v_row.parent_table);
+        END IF;
+
+    ELSIF v_control_type = 'id' THEN
+
+        IF v_row.sub_partition_set_full THEN
+            UPDATE @extschema@.part_config SET maintenance_last_run = clock_timestamp() WHERE parent_table = v_row.parent_table;
+            CONTINUE;
+        END IF;
+
+        -- Must be reset to null otherwise if the next partition set in the loop is empty, the previous partition set's value could be used
+        v_current_partition_id := NULL;
+
+        FOR v_row_max_id IN
+            SELECT partition_schemaname, partition_tablename FROM @extschema@.show_partitions(v_row.parent_table, 'DESC', false)
+        LOOP
+            -- Loop through child tables starting from highest to get current max value in partition set
+            -- Avoids doing a scan on entire partition set and/or getting any values accidentally in default.
+            EXECUTE format('SELECT trunc(max(%I))::bigint FROM %I.%I'
+                            , v_row.control
+                            , v_row_max_id.partition_schemaname
+                            , v_row_max_id.partition_tablename) INTO v_max_id;
+            IF v_max_id IS NOT NULL THEN
+                SELECT suffix_id INTO v_current_partition_id FROM @extschema@.show_partition_name(v_row.parent_table, v_max_id::text);
+                EXIT;
+            END IF;
+        END LOOP;
+        -- If not ignoring the default table, check for max values there. If they are there and greater than all child values, use that instead
+        -- Note the default is NOT to care about data in the default, so maintenance will fail if new child table boundaries overlap with
+        --  data that exists in the default. This is intentional so user removes data from default to avoid larger problems.
+        IF v_row.ignore_default_data THEN
+            v_max_id_default := NULL;
+        ELSE
+            EXECUTE format('SELECT trunc(max(%I))::bigint FROM ONLY %I.%I', v_row.control, v_parent_schema, v_default_tablename) INTO v_max_id_default;
+        END IF;
+        RAISE DEBUG 'run_maint: v_max_id: %, v_current_partition_id: %, v_max_id_default: %', v_max_id, v_current_partition_id, v_max_id_default;
+        IF v_current_partition_id IS NULL AND v_max_id_default IS NULL THEN
+            -- Partition set is completely empty.
+
+            -- Still need to run retention if needed. Note similar call below for non-empty sets. Keep in sync.
+            IF v_row.retention IS NOT NULL THEN
+                v_drop_count := v_drop_count + @extschema@.drop_partition_id(v_row.parent_table);
+            END IF;
+
+            -- Nothing else to do
+            UPDATE @extschema@.part_config SET maintenance_last_run = clock_timestamp() WHERE parent_table = v_row.parent_table;
+            CONTINUE;
+        END IF;
+        IF v_current_partition_id IS NULL OR (v_max_id_default > v_current_partition_id) THEN
+            SELECT suffix_id INTO v_current_partition_id FROM @extschema@.show_partition_name(v_row.parent_table, v_max_id_default::text);
+        END IF;
+
+        SELECT child_start_id INTO v_last_partition_id
+            FROM @extschema@.show_partition_info(v_parent_schema||'.'||v_last_partition, v_row.partition_interval, v_row.parent_table);
+        -- Determine if this table is a child of a subpartition parent. If so, get limits to see if run_maintenance even needs to run for it.
+        SELECT sub_min::bigint, sub_max::bigint INTO v_sub_id_min, v_sub_id_max FROM @extschema@.check_subpartition_limits(v_row.parent_table, 'id');
+
+        IF v_sub_id_max IS NOT NULL THEN
+            SELECT suffix_id INTO v_sub_id_max_suffix FROM @extschema@.show_partition_name(v_row.parent_table, v_sub_id_max::text);
+            IF v_sub_id_max_suffix = v_last_partition_id THEN
+                -- Final partition for this set is created. Set full and skip it
+                UPDATE @extschema@.part_config
+                SET sub_partition_set_full = true, maintenance_last_run = clock_timestamp()
+                WHERE parent_table = v_row.parent_table;
+                CONTINUE;
+            END IF;
+        END IF;
+
+        v_next_partition_id := v_last_partition_id;
+        v_premade_count := ((v_last_partition_id - v_current_partition_id) / v_row.partition_interval::bigint);
+        -- Loop premaking until config setting is met. Allows it to catch up if it fell behind or if premake changed.
+        RAISE DEBUG 'run_maint: before child creation loop: parent_table: %, v_last_partition_id: %, v_premade_count: %, v_next_partition_id: %', v_row.parent_table, v_last_partition_id, v_premade_count, v_next_partition_id;
+        WHILE (v_premade_count < v_row.premake) LOOP
+            RAISE DEBUG 'run_maint: parent_table: %, v_premade_count: %, v_next_partition_id: %', v_row.parent_table, v_premade_count, v_next_partition_id;
+            IF v_next_partition_id < v_sub_id_min OR v_next_partition_id > v_sub_id_max THEN
+                -- With subpartitioning, no need to run if the id is not in the parent table's range
+                EXIT;
+            END IF;
+            v_next_partition_id := v_next_partition_id + v_row.partition_interval::bigint;
+            v_last_partition_created := @extschema@.create_partition_id(v_row.parent_table, ARRAY[v_next_partition_id]);
+            IF v_last_partition_created THEN
+                v_analyze := true;
+                v_create_count := v_create_count + 1;
+            END IF;
+            v_premade_count := ((v_next_partition_id - v_current_partition_id) / v_row.partition_interval::bigint);
+        END LOOP;
+
+        -- Run retention if needed. Note similar call above when partition set is empty. Keep in sync.
+        IF v_row.retention IS NOT NULL THEN
+            v_drop_count := v_drop_count + @extschema@.drop_partition_id(v_row.parent_table);
+        END IF;
+
+    END IF; -- end main IF check for time or id
+
+    IF v_analyze AND p_analyze THEN
+        IF v_jobmon_schema IS NOT NULL THEN
+            v_step_id := add_step(v_job_id, format('Analyzing partition set: %s', v_row.parent_table));
+        END IF;
+
+        EXECUTE format('ANALYZE %I.%I',v_parent_schema, v_parent_tablename);
+
+        IF v_jobmon_schema IS NOT NULL THEN
+            PERFORM update_step(v_step_id, 'OK', 'Done');
+        END IF;
+    END IF;
+
+    UPDATE @extschema@.part_config SET maintenance_last_run = clock_timestamp() WHERE parent_table = v_row.parent_table;
+
+END LOOP; -- end of main loop through part_config
+
+IF v_jobmon_schema IS NOT NULL THEN
+    v_step_id := add_step(v_job_id, format('Finished maintenance'));
+    PERFORM update_step(v_step_id, 'OK', format('Partition maintenance finished. %s partitions made. %s partitions dropped.', v_create_count, v_drop_count));
+    IF v_step_overflow_id IS NOT NULL THEN
+        PERFORM fail_job(v_job_id);
+    ELSE
+        PERFORM close_job(v_job_id);
+    END IF;
+END IF;
+
+EXCEPTION
+    WHEN OTHERS THEN
+        GET STACKED DIAGNOSTICS ex_message = MESSAGE_TEXT,
+                                ex_context = PG_EXCEPTION_CONTEXT,
+                                ex_detail = PG_EXCEPTION_DETAIL,
+                                ex_hint = PG_EXCEPTION_HINT;
+        IF v_jobmon_schema IS NOT NULL THEN
+            IF v_job_id IS NULL THEN
+                EXECUTE format('SELECT %I.add_job(''PARTMAN RUN MAINTENANCE'')', v_jobmon_schema) INTO v_job_id;
+                EXECUTE format('SELECT %I.add_step(%s, ''EXCEPTION before job logging started'')', v_jobmon_schema, v_job_id, p_parent_table) INTO v_step_id;
+            ELSIF v_step_id IS NULL THEN
+                EXECUTE format('SELECT %I.add_step(%s, ''EXCEPTION before first step logged'')', v_jobmon_schema, v_job_id) INTO v_step_id;
+            END IF;
+            EXECUTE format('SELECT %I.update_step(%s, ''CRITICAL'', %L)', v_jobmon_schema, v_step_id, 'ERROR: '||coalesce(SQLERRM,'unknown'));
+            EXECUTE format('SELECT %I.fail_job(%s)', v_jobmon_schema, v_job_id);
+        END IF;
+        RAISE EXCEPTION '%
+CONTEXT: %
+DETAIL: %
+HINT: %', ex_message, ex_context, ex_detail, ex_hint;
+END
+$$;
+
+
+CREATE OR REPLACE FUNCTION @extschema@.dump_partitioned_table_definition(
+    p_parent_table text,
+    p_ignore_template_table boolean DEFAULT false
+)
+    RETURNS text
+    LANGUAGE PLPGSQL STABLE
+    SET search_path = @extschema@, pg_catalog, pg_temp
+    AS $$
+DECLARE
+    v_create_partition_definition text;
+    v_update_part_config_definition text;
+    -- Columns from part_config table.
+    v_parent_table text; -- NOT NULL
+    v_control text; -- NOT NULL
+    v_partition_type text; -- NOT NULL
+    v_partition_interval text; -- NOT NULL
+    v_constraint_cols TEXT[];
+    v_premake integer; -- NOT NULL
+    v_optimize_constraint integer; -- NOT NULL
+    v_epoch text; -- NOT NULL
+    v_retention text;
+    v_retention_schema text;
+    v_retention_keep_index boolean;
+    v_retention_keep_table boolean; -- NOT NULL
+    v_infinite_time_partitions boolean; -- NOT NULL
+    v_datetime_string text;
+    v_automatic_maintenance text; -- NOT NULL
+    v_jobmon boolean; -- NOT NULL
+    v_sub_partition_set_full boolean; -- NOT NULL
+    v_template_table text;
+    v_inherit_privileges boolean; -- DEFAULT false
+    v_constraint_valid boolean; -- DEFAULT true NOT NULL
+    v_ignore_default_data boolean; -- DEFAULT false NOT NULL
+    v_date_trunc_interval text;
+    v_maintenance_order int;
+    v_retention_keep_publication boolean;
+    v_partition_timezone text;
+    v_parent_schemaname text;
+    v_parent_tablename text;
+    v_default_exists boolean;
+    v_default_tablename text;
+    v_sql text;
+    v_notnull boolean;
+BEGIN
+    SELECT
+        pc.parent_table,
+        pc.control,
+        pc.partition_type,
+        pc.partition_interval,
+        pc.constraint_cols,
+        pc.premake,
+        pc.optimize_constraint,
+        pc.epoch,
+        pc.retention,
+        pc.retention_schema,
+        pc.retention_keep_index,
+        pc.retention_keep_table,
+        pc.infinite_time_partitions,
+        pc.datetime_string,
+        pc.automatic_maintenance,
+        pc.jobmon,
+        pc.sub_partition_set_full,
+        pc.template_table,
+        pc.inherit_privileges,
+        pc.constraint_valid,
+        pc.ignore_default_data,
+        pc.date_trunc_interval,
+        pc.maintenance_order,
+        pc.retention_keep_publication,
+        pc.partition_timezone
+    INTO
+        v_parent_table,
+        v_control,
+        v_partition_type,
+        v_partition_interval,
+        v_constraint_cols,
+        v_premake,
+        v_optimize_constraint,
+        v_epoch,
+        v_retention,
+        v_retention_schema,
+        v_retention_keep_index,
+        v_retention_keep_table,
+        v_infinite_time_partitions,
+        v_datetime_string,
+        v_automatic_maintenance,
+        v_jobmon,
+        v_sub_partition_set_full,
+        v_template_table,
+        v_inherit_privileges,
+        v_constraint_valid,
+        v_ignore_default_data,
+        v_date_trunc_interval,
+        v_maintenance_order,
+        v_retention_keep_publication,
+        v_partition_timezone
+    FROM @extschema@.part_config pc
+    WHERE pc.parent_table = p_parent_table;
+
+    IF v_parent_table IS NULL THEN
+        RAISE EXCEPTION 'Given parent table not found in pg_partman configuration table: %', p_parent_table;
+    END IF;
+
+    IF p_ignore_template_table THEN
+        v_template_table := NULL;
+    END IF;
+
+    SELECT schemaname, tablename
+    INTO v_parent_schemaname, v_parent_tablename
+    FROM pg_catalog.pg_tables
+    WHERE schemaname = split_part(p_parent_table, '.', 1)::name
+    AND tablename = split_part(p_parent_table, '.', 2)::name;
+
+    -- Check to see if table has a default
+    v_sql := format('SELECT c.relname
+            FROM pg_catalog.pg_inherits h
+            JOIN pg_catalog.pg_class c ON c.oid = h.inhrelid
+            JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
+            WHERE h.inhparent = ''%I.%I''::regclass
+            AND pg_get_expr(relpartbound, c.oid) = ''DEFAULT'''
+        , v_parent_schemaname
+        , v_parent_tablename);
+
+    EXECUTE v_sql INTO v_default_tablename;
+    IF v_default_tablename IS NOT NULL THEN
+        v_default_exists := true;
+    ELSE
+        v_default_exists := false;
+    END IF;
+
+    SELECT attnotnull INTO v_notnull
+    FROM pg_catalog.pg_attribute a
+    JOIN pg_catalog.pg_class c ON a.attrelid = c.oid
+    JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
+    WHERE c.relname = v_parent_tablename::name
+    AND n.nspname = v_parent_schemaname::name
+    AND a.attname = v_control::name;
+
+    v_create_partition_definition := format(
+E'SELECT @extschema@.create_partition(
+\tp_parent_table := %L,
+\tp_control := %L,
+\tp_interval := %L,
+\tp_type := %L,
+\tp_epoch := %L,
+\tp_premake := %s,
+\tp_default_table := %L,
+\tp_automatic_maintenance := %L,
+\tp_constraint_cols := %L,
+\tp_template_table := %L,
+\tp_jobmon := %L,
+\tp_date_trunc_interval := %L,
+\tp_control_not_null := %L,
+\tp_timezone := %L
+);',
+            v_parent_table,
+            v_control,
+            v_partition_interval,
+            v_partition_type,
+            v_epoch,
+            v_premake,
+            v_default_exists,
+            v_automatic_maintenance,
+            v_constraint_cols,
+            v_template_table,
+            v_jobmon,
+            v_date_trunc_interval,
+            v_notnull,
+            v_partition_timezone
+        );
+
+    v_update_part_config_definition := format(
+E'UPDATE @extschema@.part_config SET
+\toptimize_constraint = %s,
+\tretention = %L,
+\tretention_schema = %L,
+\tretention_keep_index = %L,
+\tretention_keep_table = %L,
+\tinfinite_time_partitions = %L,
+\tdatetime_string = %L,
+\tsub_partition_set_full = %L,
+\tinherit_privileges = %L,
+\tconstraint_valid = %L,
+\tignore_default_data = %L,
+\tmaintenance_order = %L,
+\tretention_keep_publication = %L
+WHERE parent_table = %L;',
+        v_optimize_constraint,
+        v_retention,
+        v_retention_schema,
+        v_retention_keep_index,
+        v_retention_keep_table,
+        v_infinite_time_partitions,
+        v_datetime_string,
+        v_sub_partition_set_full,
+        v_inherit_privileges,
+        v_constraint_valid,
+        v_ignore_default_data,
+        v_maintenance_order,
+        v_retention_keep_publication,
+        v_parent_table
+    );
+
+    RETURN concat_ws(E'\n',
+        v_create_partition_definition,
+        v_update_part_config_definition
+    );
+END
+$$;


### PR DESCRIPTION
run_maintenance() did timestamptz month arithmetic in the session timezone, so a partition set aligned to a non-UTC zone drifted when maintenance ran from a different session (e.g. a UTC client such as DataGrip): new boundaries and child names no longer landed on the intended day.

The timezone a set is aligned to is now recorded at creation in the new part_config.partition_timezone column (overridable via p_timezone on create_parent/create_partition), and all boundary math is done in that timezone. A NULL value keeps the previous session-timezone behavior, so existing sets are unaffected until it is set. Adds an upgrade script and a pgTAP regression test.