### PR TITLE
docs: fix broken config_cleanup TOC link

### DIFF
--- a/doc/pg_partman.md
+++ b/doc/pg_partman.md
@@ -58,7 +58,7 @@ Table of Contents
     - [stop_sub_partition](#stop_sub_partition)
  - [Destruction Objects](#destruction-objects)
     - [undo_partition](#undo_partition)
-    - [config_cleanup](config_cleanup)
+    - [config_cleanup](#config_cleanup())
     - [drop_partition_time](#drop_partition_time)
     - [drop_partition_id](#drop_partition_id)
  - [Configuration Tables](#configuration-tables)


### PR DESCRIPTION
In `doc/pg_partman.md`, the `config_cleanup` entry in the function-reference table of contents links to `config_cleanup`:

    - [config_cleanup](config_cleanup)

That resolves to a nonexistent relative path instead of the section anchor, so clicking it does nothing. It is the only one of the 46 TOC entries missing its leading `#` (the neighbours use `#undo_partition` and `#drop_partition_time`). The section anchor exists (`<a id="config_cleanup()">`), so this points the link there.
